### PR TITLE
Pair of CopInsT to store 32-bit pointers

### DIFF
--- a/effects/anim-polygons/anim-polygons.c
+++ b/effects/anim-polygons/anim-polygons.c
@@ -14,7 +14,7 @@
 #define DEPTH 4
 
 static BitmapT *screen;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static CopListT *cp;
 static short active = 0;
 static short maybeSkipFrame = 0;
@@ -27,7 +27,7 @@ static short current_frame = 0;
 
 static void MakeCopperList(CopListT *cp) {
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   {
     short *pixels = gradient.pixels;
     short i, j;
@@ -127,7 +127,7 @@ static void Render(void) {
     while (--n >= 0) {
       short i = mod16(active + n + 1 - DEPTH, DEPTH + 1);
       if (i < 0) i += DEPTH + 1;
-      CopInsSet32(bplptr[n], screen->planes[i]);
+      CopInsSet32(&bplptr[n], screen->planes[i]);
     }
   }
 

--- a/effects/anim/anim.c
+++ b/effects/anim/anim.c
@@ -10,7 +10,7 @@
 #define DEPTH  4
 
 static BitmapT *screen;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static CopListT *cp;
 static short active = 0;
 
@@ -43,7 +43,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 
   CopListActivate(cp);
@@ -100,7 +100,7 @@ static void Render(void) {
       short i = (active + n + 1 - DEPTH) % (DEPTH + 1);
       if (i < 0)
         i += DEPTH + 1;
-      CopInsSet32(bplptr[n], screen->planes[i]);
+      CopInsSet32(&bplptr[n], screen->planes[i]);
     }
   }
 

--- a/effects/ball/ball.c
+++ b/effects/ball/ball.c
@@ -18,7 +18,7 @@ static PixmapT *chunky;
 static BitmapT *bitmap;
 static SprDataT *sprdat;
 static SpriteT sprite[2][8];
-static CopInsT *sprptr[8];
+static CopInsPairT *sprptr;
 
 #include "data/dragon-bg.c"
 #include "data/texture-15.c"
@@ -81,15 +81,15 @@ static void MakeUVMapRenderCode(void) {
 
 static void MakeCopperList(CopListT *cp) {
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, &background, S_DEPTH);
-  CopSetupSprites(cp, sprptr);
+  CopSetupBitplanes(cp, &background, S_DEPTH);
+  sprptr = CopSetupSprites(cp);
   CopEnd(cp);
 
   {
     short i;
 
     for (i = 0; i < 8; i++)
-      CopInsSetSprite(sprptr[i], &sprite[active][i]);
+      CopInsSetSprite(&sprptr[i], &sprite[active][i]);
   }
 }
 
@@ -308,7 +308,7 @@ static void BitmapToSprite(BitmapT *input, SpriteT sprite[8]) {
 static void PositionSprite(SpriteT sprite[8], short xo, short yo) {
   short x = X((S_WIDTH - WIDTH) / 2) + xo;
   short y = Y((S_HEIGHT - HEIGHT) / 2) + yo;
-  CopInsT **ptr = sprptr;
+  CopInsPairT *ptr = sprptr;
   short n = 4;
 
   while (--n >= 0) {
@@ -318,8 +318,8 @@ static void PositionSprite(SpriteT sprite[8], short xo, short yo) {
     SpriteUpdatePos(spr0, x, y);
     SpriteUpdatePos(spr1, x, y);
 
-    CopInsSetSprite(*ptr++, spr0);
-    CopInsSetSprite(*ptr++, spr1);
+    CopInsSetSprite(ptr++, spr0);
+    CopInsSetSprite(ptr++, spr1);
 
     x += 16;
   }

--- a/effects/blurred3d/blurred3d.c
+++ b/effects/blurred3d/blurred3d.c
@@ -15,7 +15,7 @@
 
 static Object3D *cube;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static BitmapT *screen0, *screen1;
 static BitmapT *scratchpad;
 static BitmapT *carry;
@@ -36,7 +36,7 @@ static void UnLoad(void) {
 
 static void MakeCopperList(CopListT *cp) {
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen0, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen0, DEPTH);
 
   {
     short *pixels = gradient.pixels;
@@ -488,7 +488,7 @@ static void Render(void) {
     short n = DEPTH;
 
     while (--n >= 0)
-      CopInsSet32(bplptr[n], screen0->planes[n]);
+      CopInsSet32(&bplptr[n], screen0->planes[n]);
   }
 
   TaskWaitVBlank();

--- a/effects/bobs3d/bobs3d.c
+++ b/effects/bobs3d/bobs3d.c
@@ -13,7 +13,7 @@
 static Object3D *cube;
 static CopListT *cp;
 static BitmapT *screen0, *screen1;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 
 #include "data/flares32.c"
 #include "data/pilka.c"
@@ -23,7 +23,7 @@ static Mesh3D *mesh = &pilka;
 static void MakeCopperList(CopListT *cp) {
   CopInit(cp);
   CopWait(cp, Y(-1), 0);
-  CopSetupBitplanes(cp, bplptr, screen1, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen1, DEPTH);
   CopEnd(cp);
 }
 

--- a/effects/bumpmap-rgb/bumpmap-rgb.c
+++ b/effects/bumpmap-rgb/bumpmap-rgb.c
@@ -18,7 +18,7 @@ static u_short *shademap;
 static u_short *colormap;
 static u_short *chunky[2];
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 
 #include "data/dragon.c"
 #include "data/light.c"
@@ -250,10 +250,10 @@ static void ChunkyToPlanar(void) {
       break;
 
     case 12:
-      CopInsSet32(bplptr[0], bpl[3]);
-      CopInsSet32(bplptr[1], bpl[2]);
-      CopInsSet32(bplptr[2], bpl[1]);
-      CopInsSet32(bplptr[3], bpl[0]);
+      CopInsSet32(&bplptr[0], bpl[3]);
+      CopInsSet32(&bplptr[1], bpl[2]);
+      CopInsSet32(&bplptr[2], bpl[1]);
+      CopInsSet32(&bplptr[3], bpl[0]);
       break;
 
     default:
@@ -269,7 +269,7 @@ static void MakeCopperList(CopListT *cp) {
   short i;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadColor(cp, 0, 15, 0);
   for (i = 0; i < HEIGHT * 4; i++) {
     CopWaitSafe(cp, Y(i), 0);

--- a/effects/butterfly-gears/butterfly-gears.c
+++ b/effects/butterfly-gears/butterfly-gears.c
@@ -106,7 +106,7 @@ static void MakeBallCopperList(BallCopListT *ballCp) {
   CopInit(cp);
   CopMove16(cp, dmacon, DMAF_SETCLR | DMAF_RASTER);
   CopLoadPal(cp, &testscreen_pal, 0);
-  CopSetupBitplanes(cp, NULL, &testscreen, testscreen.depth);
+  CopSetupBitplanes(cp, &testscreen, testscreen.depth);
 
   ballCp->upperBallCopper = cp->curr;
   InitCopperListBall(cp, Y0 + 2, 2);

--- a/effects/circles/circles.c
+++ b/effects/circles/circles.c
@@ -18,7 +18,7 @@ static void Init(void) {
   SetColor(1, 0xfff);
 
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 
   CopListActivate(cp);

--- a/effects/credits/credits.c
+++ b/effects/credits/credits.c
@@ -61,7 +61,7 @@ static void MakeCopperList(CopListT *cp) {
   CopWaitSafe(cp, DISCO_Y - 1, 0);
   CopLoadPal(cp, &disco_pal, 0);
   CopSetupMode(cp, MODE_LORES, disco.depth);
-  CopSetupBitplanes(cp, NULL, &disco, disco.depth);
+  CopSetupBitplanes(cp, &disco, disco.depth);
   CopSetupBitplaneFetch(cp, MODE_LORES, DISCO_X, disco.width);
 
   CopWaitSafe(cp, DISCO_Y, 0);

--- a/effects/flatshade-convex/flatshade-convex.c
+++ b/effects/flatshade-convex/flatshade-convex.c
@@ -11,7 +11,7 @@
 
 static Object3D *cube;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static BitmapT *screen[2];
 static short active;
 
@@ -42,7 +42,7 @@ static void Init(void) {
 
   cp = NewCopList(80);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[0], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[0], DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_BLITTER | DMAF_RASTER | DMAF_BLITHOG);

--- a/effects/flatshade/flatshade.c
+++ b/effects/flatshade/flatshade.c
@@ -10,7 +10,7 @@
 
 static Object3D *cube;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static BitmapT *screen0, *screen1;
 static BitmapT *buffer;
 
@@ -40,7 +40,7 @@ static void Init(void) {
 
   cp = NewCopList(80);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen0, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen0, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_BLITTER | DMAF_RASTER | DMAF_BLITHOG);

--- a/effects/floor-old/floor-old.c
+++ b/effects/floor-old/floor-old.c
@@ -99,7 +99,7 @@ static void MakeCopperList(CopListT *cp, short num) {
   short i, j;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen[num], DEPTH);
+  CopSetupBitplanes(cp, screen[num], DEPTH);
   CopLoadColor(cp, 0, 3, 0);
 
   for (i = 0; i < FAR_Y; i++) {

--- a/effects/floor/floor.c
+++ b/effects/floor/floor.c
@@ -70,7 +70,7 @@ static void MakeCopperList(CopListT *cp, short n) {
   short i;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, &floor, DEPTH);
+  CopSetupBitplanes(cp, &floor, DEPTH);
 
   for (i = 0; i < HEIGHT; i++) {
     CopWait(cp, Y(i), 0);

--- a/effects/game-of-life/game-of-life.c
+++ b/effects/game-of-life/game-of-life.c
@@ -318,11 +318,9 @@ static void MakeCopperList(CopListT *cp) {
   // initially previous states are empty
   // save addresses of these instructions to change bitplane
   // order when new state gets generated
-  for (i = 0; i < DISP_DEPTH; i++) {
-    CopInsPairT *ins = CopMove32(cp, bplpt[i], prev_states[i]->planes[0]);
-    if (!bplptr)
-      bplptr = ins;
-  }
+  bplptr = CopInsPtr(cp);
+  for (i = 0; i < DISP_DEPTH; i++) 
+    CopMove32(cp, bplpt[i], prev_states[i]->planes[0]);
 
   palptr = CopLoadPal(cp, &palette, 0);
 

--- a/effects/game-of-life/game-of-life.c
+++ b/effects/game-of-life/game-of-life.c
@@ -93,10 +93,10 @@ static BitmapT *current_board;
 static BitmapT *boards[BOARD_COUNT];
 
 // pointers to copper instructions, for rewriting bitplane pointers
-static CopInsT *bplptr[DISP_DEPTH];
+static CopInsPairT *bplptr;
 
 // pointers to copper instructions, for setting colors
-static CopInsT *palptr[COLORS];
+static CopInsT *palptr;
 
 // circular buffer of previous game states as they would be rendered (with
 // horizontally doubled pixels)
@@ -305,25 +305,26 @@ static void ChangePalette(const u_short* pal) {
     {
       u_short next_i = i << 1;
       for (j = i; j < next_i; j++)
-        CopInsSet16(palptr[j], *pal);
+        CopInsSet16(&palptr[j], *pal);
       i = next_i;
       pal++;
     }
 }
 
 static void MakeCopperList(CopListT *cp) {
-  u_short i;
-  u_short* color = palette.colors;
+  short i;
 
   CopInit(cp);
   // initially previous states are empty
   // save addresses of these instructions to change bitplane
   // order when new state gets generated
-  for (i = 0; i < DISP_DEPTH; i++)
-    bplptr[i] = CopMove32(cp, bplpt[i], prev_states[i]->planes[0]);
+  for (i = 0; i < DISP_DEPTH; i++) {
+    CopInsPairT *ins = CopMove32(cp, bplpt[i], prev_states[i]->planes[0]);
+    if (!bplptr)
+      bplptr = ins;
+  }
 
-  for (i = 0; i < COLORS; i++)
-    palptr[i] = CopSetColor(cp, i, *color++);
+  palptr = CopLoadPal(cp, &palette, 0);
 
   for (i = 1; i <= DISP_HEIGHT; i += 2) {
     // vertical pixel doubling
@@ -347,7 +348,7 @@ static void UpdateBitplanePointers(void) {
     // state) to newest game state, so 0th bitplane displays the oldest+1 state
     // and (PREV_STATES_DEPTH-1)'th bitplane displays the newest state
     cur = prev_states[(states_head + i + 1) % PREV_STATES_DEPTH];
-    CopInsSet32(bplptr[i - 1], cur->planes[0]);
+    CopInsSet32(&bplptr[i - 1], cur->planes[0]);
   }
 }
 

--- a/effects/glitch/glitch.c
+++ b/effects/glitch/glitch.c
@@ -11,7 +11,7 @@
 
 static BitmapT *screen[2];
 static short active = 0;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static CopListT *cp;
 static CopInsT *line[HEIGHT];
 
@@ -65,7 +65,7 @@ static void Init(void) {
 
   cp = NewCopList(100 + HEIGHT * 2);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   for (i = 0; i < HEIGHT; i++) {
     CopWait(cp, Y(YSTART + i), 0);
     /* Alternating shift by one for bitplane data. */
@@ -128,7 +128,7 @@ static void Render(void) {
 
   ProfilerStop(RenderGlitch);
 
-  ITER(i, 0, DEPTH - 1, CopInsSet32(bplptr[i], screen[active]->planes[i]));
+  ITER(i, 0, DEPTH - 1, CopInsSet32(&bplptr[i], screen[active]->planes[i]));
   TaskWaitVBlank();
   active ^= 1;
 }

--- a/effects/growing-tree/growing-tree.c
+++ b/effects/growing-tree/growing-tree.c
@@ -12,7 +12,7 @@
 #define DEPTH 2
 
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static BitmapT *screen;
 
 #include "data/fruit.c"
@@ -153,7 +153,7 @@ static void Init(void) {
 
   cp = NewCopList(50);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
 

--- a/effects/gui/gui.c
+++ b/effects/gui/gui.c
@@ -14,7 +14,7 @@
 
 static BitmapT *screen;
 static CopListT *cp;
-static CopInsT *sprptr[8];
+static CopInsPairT *sprptr;
 
 #include "data/toggle_0.c"
 #include "data/toggle_1.c"
@@ -74,11 +74,11 @@ static void Init(void) {
 
   cp = NewCopList(120);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
-  CopSetupSprites(cp, sprptr);
+  CopSetupBitplanes(cp, screen, DEPTH);
+  sprptr = CopSetupSprites(cp);
   CopEnd(cp);
 
-  CopInsSetSprite(sprptr[0], &pointer);
+  CopInsSetSprite(&sprptr[0], &pointer);
   SpriteUpdatePos(&pointer, X(0), Y(0));
 
   CopListActivate(cp);

--- a/effects/highway/highway.c
+++ b/effects/highway/highway.c
@@ -32,8 +32,8 @@ static Car cars[CARS];
 
 static CopListT *cp;
 static u_short active = 0;
-static CopInsT *sprptr[8];
-static CopInsT *bplptr[2][DEPTH];
+static CopInsPairT *sprptr;
+static CopInsPairT *bplptr[2];
 static BitmapT *carry;
 
 #include "data/car-left-2.c"
@@ -47,9 +47,9 @@ static BitmapT *lanes[2];
 
 static void MakeCopperList(CopListT *cp) {
   CopInit(cp);
-  CopSetupSprites(cp, sprptr);
+  sprptr = CopSetupSprites(cp);
 
-  CopSetupBitplanes(cp, NULL, &city_top, DEPTH);
+  CopSetupBitplanes(cp, &city_top, DEPTH);
   CopWait(cp, Y(-18), 0);
   CopLoadPal(cp, &city_top_pal, 0);
 
@@ -59,7 +59,7 @@ static void MakeCopperList(CopListT *cp) {
     CopWait(cp, Y(LANEL_Y - 2), 8);
     CopMove16(cp, dmacon, DMAF_RASTER);
     CopLoadPal(cp, &car_left_pal, 0);
-    CopSetupBitplanes(cp, bplptr[0], lanes[active], DEPTH);
+    bplptr[0] = CopSetupBitplanes(cp, lanes[active], DEPTH);
     CopMove16(cp, bpl1mod, 8);
     CopMove16(cp, bpl2mod, 8);
 
@@ -85,7 +85,7 @@ static void MakeCopperList(CopListT *cp) {
   {
     CopWait(cp, Y(LANER_Y - 1), 8);
     CopLoadPal(cp, &car_right_pal, 0);
-    CopSetupBitplanes(cp, bplptr[1], lanes[active], DEPTH);
+    bplptr[1] = CopSetupBitplanes(cp, lanes[active], DEPTH);
     CopMove16(cp, bpl1mod, 8);
     CopMove16(cp, bpl2mod, 8);
 
@@ -98,14 +98,14 @@ static void MakeCopperList(CopListT *cp) {
   {
     CopWait(cp, Y(LANER_Y + LANE_H + 1), 8);
     CopLoadPal(cp, &city_bottom_pal, 0);
-    CopSetupBitplanes(cp, NULL, &city_bottom, DEPTH);
+    CopSetupBitplanes(cp, &city_bottom, DEPTH);
     CopWait(cp, Y(LANER_Y + LANE_H + 2), 8);
     CopMove16(cp, dmacon, DMAF_SETCLR | DMAF_RASTER);
   }
 
   CopEnd(cp);
 
-  ITER(i, 0, 7, CopInsSetSprite(sprptr[i], &sprite[i]));
+  ITER(i, 0, 7, CopInsSetSprite(&sprptr[i], &sprite[i]));
 }
 
 static void Init(void) {
@@ -207,8 +207,8 @@ static void Render(void) {
     for (i = 0; i < DEPTH; i++) {
       void *bplpt = lanes[active]->planes[i] + 4;
       u_short stride = lanes[active]->bytesPerRow;
-      CopInsSet32(bplptr[0][i], bplpt);
-      CopInsSet32(bplptr[1][i], bplpt + stride * LANE_H);
+      CopInsSet32(&bplptr[0][i], bplpt);
+      CopInsSet32(&bplptr[1][i], bplpt + stride * LANE_H);
     }
   }
 

--- a/effects/kbtest/kbtest.c
+++ b/effects/kbtest/kbtest.c
@@ -26,7 +26,7 @@ static void Init(void) {
   SetColor(1, 0xfff);
 
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);

--- a/effects/lines/lines.c
+++ b/effects/lines/lines.c
@@ -37,7 +37,7 @@ static void Load(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 }
 

--- a/effects/metaballs/metaballs.c
+++ b/effects/metaballs/metaballs.c
@@ -15,7 +15,7 @@ static short active = 0;
 
 static Point2D pos[2][3];
 static BitmapT *carry;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static CopListT *cp;
 
 #include "data/metaball.c"
@@ -63,7 +63,7 @@ static void Init(void) {
   LoadPalette(&metaball_pal, 0);
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
@@ -122,7 +122,7 @@ static void Render(void) {
   }
   ProfilerStop(Metaballs);
 
-  ITER(i, 0, DEPTH - 1, CopInsSet32(bplptr[i], screen[active]->planes[i]));
+  ITER(i, 0, DEPTH - 1, CopInsSet32(&bplptr[i], screen[active]->planes[i]));
   TaskWaitVBlank();
   active ^= 1;
 }

--- a/effects/multipipe/multipipe.c
+++ b/effects/multipipe/multipipe.c
@@ -178,7 +178,7 @@ static void RenderPipes(void) {
           "addl %1,%0"
           : "+d" (line) : "d" (off) : "1");
 #endif
-      CopInsSet32(ins + 1, line);
+      CopInsSet32((CopInsPairT *)&ins[1], line);
     }
 
     /* Shift bitplanes */

--- a/effects/multipipe/multipipe.c
+++ b/effects/multipipe/multipipe.c
@@ -15,10 +15,10 @@ typedef struct {
   CopInsPairT bplptr1;
   CopInsT color0;
   CopInsT color1;
-} CopInsLineT;
+} CopLineT;
 
 static CopListT *cp[2];
-static CopInsLineT *copLine[2][HEIGHT];
+static CopLineT *copLines[2][HEIGHT];
 static short active = 1;
 
 #include "stripes.c"
@@ -98,7 +98,7 @@ static void UnLoad(void) {
     MemFree(cache[s]);
 }
 
-static void MakeCopperList(CopListT *cp, CopInsLineT **line) {
+static void MakeCopperList(CopListT *cp, CopLineT **line) {
   short i;
   void *data = cache[0];
 
@@ -107,7 +107,7 @@ static void MakeCopperList(CopListT *cp, CopInsLineT **line) {
   CopSetColor(cp, 1, 0x000);
   for (i = 0; i < HEIGHT; i++) {
     CopWaitSafe(cp, Y(i), 0);
-    line[i] = (CopInsLineT *)CopMove16(cp, bplcon1, 0x00);
+    line[i] = (CopLineT *)CopMove16(cp, bplcon1, 0x00);
     CopMove32(cp, bplpt[0], data + EMPTY * CWIDTH / 8);
     CopMove32(cp, bplpt[1], data + FULL * CWIDTH / 8);
     CopSetColor(cp, 2, 0x000);
@@ -125,8 +125,8 @@ static void Init(void) {
 
   cp[0] = NewCopList(50 + HEIGHT * 8);
   cp[1] = NewCopList(50 + HEIGHT * 8);
-  MakeCopperList(cp[0], copLine[0]);
-  MakeCopperList(cp[1], copLine[1]);
+  MakeCopperList(cp[0], copLines[0]);
+  MakeCopperList(cp[1], copLines[1]);
   CopListActivate(cp[0]);
   EnableDMA(DMAF_RASTER);
 }
@@ -139,7 +139,7 @@ static void Kill(void) {
 
 static void RenderPipes(void) {
   u_short *pixels = (u_short *)colors.pixels;
-  CopInsLineT **lineInsTab = copLine[active];
+  CopLineT **lineTab = copLines[active];
   int *offset = offsets;
   short *stripe = stripes;
   short i;
@@ -147,7 +147,7 @@ static void RenderPipes(void) {
   register int center asm("d7") = - WIDTH * STEP / 2;
 
   for (i = 0; i < HEIGHT; i++) {
-    CopInsLineT *lineIns = *lineInsTab++;
+    CopLineT *lineIns = *lineTab++;
     short w = *stripe++;
     int x = ((short)w * (short)frame) >> 3;
     short _x, _c;

--- a/effects/multipipe/multipipe.c
+++ b/effects/multipipe/multipipe.c
@@ -9,8 +9,16 @@
 #define HEIGHT 256
 #define DEPTH 2
 
+typedef struct {
+  CopInsT bplshift;
+  CopInsPairT bplptr0;
+  CopInsPairT bplptr1;
+  CopInsT color0;
+  CopInsT color1;
+} CopInsLineT;
+
 static CopListT *cp[2];
-static CopInsT *copins[2][HEIGHT];
+static CopInsLineT *copLine[2][HEIGHT];
 static short active = 1;
 
 #include "stripes.c"
@@ -90,7 +98,7 @@ static void UnLoad(void) {
     MemFree(cache[s]);
 }
 
-static void MakeCopperList(CopListT *cp, CopInsT **ins) {
+static void MakeCopperList(CopListT *cp, CopInsLineT **line) {
   short i;
   void *data = cache[0];
 
@@ -99,7 +107,7 @@ static void MakeCopperList(CopListT *cp, CopInsT **ins) {
   CopSetColor(cp, 1, 0x000);
   for (i = 0; i < HEIGHT; i++) {
     CopWaitSafe(cp, Y(i), 0);
-    ins[i] = CopMove16(cp, bplcon1, 0x00);
+    line[i] = (CopInsLineT *)CopMove16(cp, bplcon1, 0x00);
     CopMove32(cp, bplpt[0], data + EMPTY * CWIDTH / 8);
     CopMove32(cp, bplpt[1], data + FULL * CWIDTH / 8);
     CopSetColor(cp, 2, 0x000);
@@ -117,8 +125,8 @@ static void Init(void) {
 
   cp[0] = NewCopList(50 + HEIGHT * 8);
   cp[1] = NewCopList(50 + HEIGHT * 8);
-  MakeCopperList(cp[0], copins[0]);
-  MakeCopperList(cp[1], copins[1]);
+  MakeCopperList(cp[0], copLine[0]);
+  MakeCopperList(cp[1], copLine[1]);
   CopListActivate(cp[0]);
   EnableDMA(DMAF_RASTER);
 }
@@ -131,7 +139,7 @@ static void Kill(void) {
 
 static void RenderPipes(void) {
   u_short *pixels = (u_short *)colors.pixels;
-  CopInsT **ins_tab = copins[active];
+  CopInsLineT **lineInsTab = copLine[active];
   int *offset = offsets;
   short *stripe = stripes;
   short i;
@@ -139,7 +147,7 @@ static void RenderPipes(void) {
   register int center asm("d7") = - WIDTH * STEP / 2;
 
   for (i = 0; i < HEIGHT; i++) {
-    CopInsT *ins = *ins_tab++;
+    CopInsLineT *lineIns = *lineInsTab++;
     short w = *stripe++;
     int x = ((short)w * (short)frame) >> 3;
     short _x, _c;
@@ -178,11 +186,11 @@ static void RenderPipes(void) {
           "addl %1,%0"
           : "+d" (line) : "d" (off) : "1");
 #endif
-      CopInsSet32((CopInsPairT *)&ins[1], line);
+      CopInsSet32(&lineIns->bplptr0, line);
     }
 
     /* Shift bitplanes */
-    CopInsSet16(ins, getword(shifts, _x & 15));
+    CopInsSet16(&lineIns->bplshift, getword(shifts, _x & 15));
 
     /* Stripes colouring */
     {
@@ -191,8 +199,8 @@ static void RenderPipes(void) {
 
       if (_c & 1) swapr(c0, c1);
 
-      CopInsSet16(ins + 5, c0);
-      CopInsSet16(ins + 6, c1);
+      CopInsSet16(&lineIns->color0, c0);
+      CopInsSet16(&lineIns->color1, c1);
     }
   }
 }

--- a/effects/neons/neons.c
+++ b/effects/neons/neons.c
@@ -14,7 +14,7 @@
 
 static BitmapT *screen[2];
 static u_short active = 0;
-static CopInsT *bplptr[5];
+static CopInsPairT *bplptr;
 
 static const PaletteT *palette[3];
 static CopListT *cp;
@@ -132,7 +132,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   pal = CopLoadPal(cp, palette[0], 0);
   CopLoadPal(cp, palette[1], 16);
   CopLoadPal(cp, palette[2], 24);
@@ -216,7 +216,7 @@ static void Render(void) {
   }
   ProfilerStop(RenderNeons);
 
-  ITER(i, 0, DEPTH - 1, CopInsSet32(bplptr[i], screen[active]->planes[i]));
+  ITER(i, 0, DEPTH - 1, CopInsSet32(&bplptr[i], screen[active]->planes[i]));
   TaskWaitVBlank();
   active ^= 1;
 }

--- a/effects/plasma/plasma.c
+++ b/effects/plasma/plasma.c
@@ -72,7 +72,7 @@ static void MakeCopperList(CopListT *cp, CopInsT **row) {
   CopWaitV(cp, VP(0));
 
   for (y = 0; y < VTILES; y++) {
-    CopInsT *location = CopMove32(cp, cop2lc, 0);
+    CopInsPairT *location = CopMove32(cp, cop2lc, 0);
     CopInsT *label = CopWaitH(cp, VP(y * 4), HP(-4));
     CopInsSet32(location, label);
     row[y] = CopSetColor(cp, 0, 0);

--- a/effects/playahx/playahx.c
+++ b/effects/playahx/playahx.c
@@ -174,7 +174,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
 

--- a/effects/playctr/playctr.c
+++ b/effects/playctr/playctr.c
@@ -67,7 +67,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 
   ConsoleInit(&console, &latin2, screen);

--- a/effects/playp61/playp61.c
+++ b/effects/playp61/playp61.c
@@ -80,7 +80,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 
   ConsoleInit(&console, &drdos8x8, screen);

--- a/effects/playpt/playpt.c
+++ b/effects/playpt/playpt.c
@@ -32,7 +32,6 @@ void AK_Generate(void *TmpBuf asm("a1"));
 
 static void Load(void) {
   void *TmpBuf = MemAlloc(AKLANG_BUFLEN, MEMF_PUBLIC);
-  Log("Generating samples, please wait...\n");
   AK_Generate(TmpBuf);
   MemFree(TmpBuf);
 }
@@ -48,7 +47,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 
   ConsoleInit(&console, &latin2, screen);

--- a/effects/plotter/plotter.c
+++ b/effects/plotter/plotter.c
@@ -17,7 +17,7 @@
 #define MAX_H 96
 
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static BitmapT *screen[2];
 static u_short active = 0;
 
@@ -51,7 +51,7 @@ static void Init(void) {
 
   CopInit(cp);
   CopWait(cp, Y(-1), 0);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
@@ -93,7 +93,7 @@ static void Render(void) {
                   &((Area2D){0, 0, MAX_W * 2 + SIZE, MAX_H * 2 + SIZE}));
   DrawPlotter();
 
-  ITER(i, 0, DEPTH - 1, CopInsSet32(bplptr[i], screen[active]->planes[i]));
+  ITER(i, 0, DEPTH - 1, CopInsSet32(&bplptr[i], screen[active]->planes[i]));
   TaskWaitVBlank();
   active ^= 1;
 }

--- a/effects/prisms/prisms.c
+++ b/effects/prisms/prisms.c
@@ -51,7 +51,7 @@ static SpanInfoT spanInfo[HEIGHT];
 static PrismT prisms[PRISMS];
 static short active = 0;
 
-static CopInsT *sprptr[8];
+static CopInsPairT *sprptr;
 
 static u_short colorSet[NCOLORS] = {
   0xC0F, 0xF0C, 0x80F, 0xF08
@@ -120,7 +120,7 @@ static void MakeCopperList(CopListT *cp, CopInsT **cline) {
   short i;
 
   CopInit(cp);
-  CopSetupSprites(cp, sprptr);
+  sprptr = CopSetupSprites(cp);
 
   for (i = 0; i < HEIGHT; i++) {
     CopWait(cp, Y(i - 1), 0xDE);
@@ -131,7 +131,7 @@ static void MakeCopperList(CopListT *cp, CopInsT **cline) {
 
   CopEnd(cp);
 
-  ITER(i, 0, 7, CopInsSetSprite(sprptr[i], &sprite[i]));
+  ITER(i, 0, 7, CopInsSetSprite(&sprptr[i], &sprite[i]));
 }
 
 static void Init(void) {
@@ -303,7 +303,7 @@ static void DrawVisibleSpans(SpanInfoT *si, CopInsT **cline) {
 
     CopInsSet16(ins, color);
     CopInsSet16(ins + 1, bplcon2);
-    CopInsSet32(ins + 2, (void *)getlong(rowAddr, width));
+    CopInsSet32((CopInsPairT *)&ins[2], (void *)getlong(rowAddr, width));
 
     si = (SpanInfoT *)wp;
   }

--- a/effects/prisms/prisms.c
+++ b/effects/prisms/prisms.c
@@ -43,8 +43,14 @@ typedef struct {
   short color;
 } SpanInfoT;
 
+typedef struct {
+  CopInsT color;
+  CopInsT bplpri;
+  CopInsPairT bplptr;
+} CopLineT;
+
 static CopListT *cp[2];
-static CopInsT *clines[2][HEIGHT];
+static CopLineT *copLines[2][HEIGHT];
 static BitmapT *stripes;
 static void *rowAddr[WIDTH / 2];
 static SpanInfoT spanInfo[HEIGHT];
@@ -116,7 +122,7 @@ static void GenerateColorShades(void) {
   }
 }
 
-static void MakeCopperList(CopListT *cp, CopInsT **cline) {
+static void MakeCopperList(CopListT *cp, CopLineT **line) {
   short i;
 
   CopInit(cp);
@@ -124,7 +130,7 @@ static void MakeCopperList(CopListT *cp, CopInsT **cline) {
 
   for (i = 0; i < HEIGHT; i++) {
     CopWait(cp, Y(i - 1), 0xDE);
-    cline[i] = CopSetColor(cp, 1, 0);
+    line[i] = (CopLineT *)CopSetColor(cp, 1, 0);
     CopMove16(cp, bplcon2, 0);
     CopMove32(cp, bplpt[0], rowAddr[0]);
   }
@@ -151,8 +157,8 @@ static void Init(void) {
   cp[0] = NewCopList(HEIGHT * 5 + 200);
   cp[1] = NewCopList(HEIGHT * 5 + 200);
 
-  MakeCopperList(cp[0], clines[0]);
-  MakeCopperList(cp[1], clines[1]);
+  MakeCopperList(cp[0], copLines[0]);
+  MakeCopperList(cp[1], copLines[1]);
 
   ITER(i, 0, 7, SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y((256 - 24) / 2)));
 
@@ -290,7 +296,7 @@ static void DrawPrismFaces(PrismT *prism, SpanInfoT *spanInfo) {
 }
 
 
-static void DrawVisibleSpans(SpanInfoT *si, CopInsT **cline) {
+static void DrawVisibleSpans(SpanInfoT *si, CopLineT **lineTab) {
   short n = HEIGHT;
 
   while (--n >= 0) {
@@ -299,11 +305,11 @@ static void DrawVisibleSpans(SpanInfoT *si, CopInsT **cline) {
     short width = *wp++;
     short color = *wp++;
     short bplcon2 = (depth > centerZ) ? BPLCON2_PF1P2|BPLCON2_PF2P2 : 0;
-    CopInsT *ins = *cline++;
+    CopLineT *lineIns = *lineTab++;
 
-    CopInsSet16(ins, color);
-    CopInsSet16(ins + 1, bplcon2);
-    CopInsSet32((CopInsPairT *)&ins[2], (void *)getlong(rowAddr, width));
+    CopInsSet16(&lineIns->color, color);
+    CopInsSet16(&lineIns->bplpri, bplcon2);
+    CopInsSet32(&lineIns->bplptr, (void *)getlong(rowAddr, width));
 
     si = (SpanInfoT *)wp;
   }
@@ -325,7 +331,7 @@ static void RenderPrisms(short rotate) {
     prism++;
   }
 
-  DrawVisibleSpans(spanInfo, clines[active]);
+  DrawVisibleSpans(spanInfo, copLines[active]);
 }
 
 PROFILE(RenderPrisms);

--- a/effects/rotator/rotator.c
+++ b/effects/rotator/rotator.c
@@ -15,7 +15,7 @@ static u_short *textureHi, *textureLo;
 static BitmapT *screen[2];
 static u_short active = 0;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 
 #include "data/rork-128.c"
 
@@ -178,10 +178,10 @@ static void ChunkyToPlanar(void) {
       break;
 
     case 6:
-      CopInsSet32(bplptr[0], bpl[2]);
-      CopInsSet32(bplptr[1], bpl[3]);
-      CopInsSet32(bplptr[2], bpl[2] + BLTSIZE / 2);
-      CopInsSet32(bplptr[3], bpl[3] + BLTSIZE / 2);
+      CopInsSet32(&bplptr[0], bpl[2]);
+      CopInsSet32(&bplptr[1], bpl[3]);
+      CopInsSet32(&bplptr[2], bpl[2] + BLTSIZE / 2);
+      CopInsSet32(&bplptr[3], bpl[3] + BLTSIZE / 2);
       break;
 
     default:
@@ -195,7 +195,7 @@ static void MakeCopperList(CopListT *cp) {
   short i;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadPal(cp, &texture_pal, 0);
   for (i = 0; i < HEIGHT * 2; i++) {
     CopWaitSafe(cp, Y(i + 28), 0);

--- a/effects/sea-anemone/sea-anemone.c
+++ b/effects/sea-anemone/sea-anemone.c
@@ -16,7 +16,6 @@
 #define NARMS 31 /* must be power of two minus one */
 
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
 static BitmapT *screen;
 static BitmapT *circles[DIAMETER / 2];
 
@@ -188,7 +187,7 @@ static void Init(void) {
 
   cp = NewCopList(50);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
 

--- a/effects/shapes/shapes.c
+++ b/effects/shapes/shapes.c
@@ -10,7 +10,7 @@
 #define DEPTH  4
 
 static BitmapT *screen;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static CopListT *cp;
 static short plane, planeC;
 
@@ -43,7 +43,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
 
@@ -129,7 +129,7 @@ static void Render(void) {
 
   for (i = 0; i < DEPTH; i++) {
     short j = (plane + i) % DEPTH;
-    CopInsSet32(bplptr[i], screen->planes[j]);
+    CopInsSet32(&bplptr[i], screen->planes[j]);
   }
 
   TaskWaitVBlank();

--- a/effects/showpchg/showpchg.c
+++ b/effects/showpchg/showpchg.c
@@ -21,7 +21,7 @@ static void Init(void) {
   SetupPlayfield(MODE_HAM, DEPTH, xs, ys, w, h);
 
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, &face, DEPTH);
+  CopSetupBitplanes(cp, &face, DEPTH);
 
   {
     u_short *data = face_pchg;

--- a/effects/textscroll/textscroll.c
+++ b/effects/textscroll/textscroll.c
@@ -16,7 +16,7 @@
 static short active = 0;
 
 static CopListT *cp[2];
-static CopInsT *linebpl[2][HEIGHT];
+static CopInsPairT *linebpl[2][HEIGHT];
 static BitmapT *scroll;
 
 static short last_line = -1;
@@ -30,7 +30,7 @@ extern uint8_t binary_data_text_scroll_txt_start[];
 static CopListT *MakeCopperList(short n) {
   CopListT *cp = NewCopList(100 + 3 * HEIGHT);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, scroll, DEPTH);
+  CopSetupBitplanes(cp, scroll, DEPTH);
   {
     u_short i;
     void *ptr = scroll->planes[0];
@@ -92,7 +92,7 @@ static void RenderLine(u_char *dst, char *line, short size) {
 }
 
 static void SetupLinePointers(void) {
-  CopInsT **ins = linebpl[active];
+  CopInsPairT **ins = linebpl[active];
   void *plane = scroll->planes[0];
   int stride = scroll->bytesPerRow;
   int bplsize = scroll->bplSize;

--- a/effects/thunders/thunders.c
+++ b/effects/thunders/thunders.c
@@ -27,7 +27,7 @@
 
 static BitmapT *screen0, *screen1;
 static CopListT *cp0, *cp1;
-static CopInsT *sprptr[8];
+static CopInsPairT *sprptr;
 static u_short tileColor[SIZE * SIZE];
 static short tileCycle[SIZE * SIZE];
 static short tileEnergy[SIZE * SIZE];
@@ -94,8 +94,8 @@ static void Load(void) {
 
 static void MakeCopperList(CopListT *cp, BitmapT *screen) {
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
-  CopSetupSprites(cp, NULL);
+  CopSetupBitplanes(cp, screen, DEPTH);
+  CopSetupSprites(cp);
   CopEnd(cp);
 }
 
@@ -391,13 +391,13 @@ static void MakeFloorCopperList(short yo, short kyo) {
   CopMove16(cp, bpl1mod, - (WIDTH * 2) / 8);
   CopMove16(cp, bpl2mod, - (WIDTH * 2) / 8);
 
-  CopSetupSprites(cp, sprptr);
+  sprptr = CopSetupSprites(cp);
  
   {
     short i = mod16(frameCount, 10) * 2;
 
-    CopInsSetSprite(sprptr[0], &thunder[i]);
-    CopInsSetSprite(sprptr[1], &thunder[i+1]);
+    CopInsSetSprite(&sprptr[0], &thunder[i]);
+    CopInsSetSprite(&sprptr[1], &thunder[i+1]);
   }
 
   /* Clear out the colors. */

--- a/effects/tiles16/tiles16.c
+++ b/effects/tiles16/tiles16.c
@@ -16,7 +16,7 @@
 #define HTILES (WIDTH / TILEW)
 #define TILESIZE (TILEW * TILEH * DEPTH / 8)
 
-static CopInsT *bplptr[2][DEPTH];
+static CopInsPairT *bplptr[2];
 static BitmapT *screen[2];
 static CopInsT *bplcon1[2];
 static CopListT *cp[2];
@@ -53,7 +53,7 @@ static void Load(void) {
 
 static void MakeCopperList(CopListT *cp, int i) {
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr[i], screen[i], DEPTH);
+  bplptr[i] = CopSetupBitplanes(cp, screen[i], DEPTH);
   bplcon1[i] = CopMove16(cp, bplcon1, 0);
   CopEnd(cp);
 }
@@ -187,12 +187,12 @@ static void Render(void) {
 
     {
       short i;
-      CopInsT **_bplptr = bplptr[active];
+      CopInsPairT *_bplptr = bplptr[active];
       void **_planes = screen[active]->planes;
       int offset = x << 1;
 
       for (i = 0; i < DEPTH; i++)
-        CopInsSet32(_bplptr[i], _planes[i] + offset);
+        CopInsSet32(&_bplptr[i], _planes[i] + offset);
     }
     CopInsSet16(bplcon1[active], pixel | (pixel << 4));
     CopListRun(cp[active]);

--- a/effects/tiles8/tiles8.c
+++ b/effects/tiles8/tiles8.c
@@ -22,7 +22,7 @@
 #define X(x) ((x) + 0x84)
 #define HP(x) (X(x) / 2)
 
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static CopInsT *chunky[VTILES];
 static BitmapT *screen0, *screen1;
 static CopListT *cp;
@@ -62,7 +62,7 @@ static void Init(void) {
 
   CopInit(cp);
   /* X(-1) to align with copper induced color changes */
-  CopSetupBitplanes(cp, bplptr, screen1, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen1, DEPTH);
   CopWaitV(cp, VP(0));
 
   /* Copper Chunky.
@@ -85,7 +85,7 @@ static void Init(void) {
   {
     short x, y;
     for (y = 0; y < VTILES; y++) {
-      CopInsT *location = CopMove32(cp, cop2lc, 0);
+      CopInsPairT *location = CopMove32(cp, cop2lc, 0);
       CopInsT *label = CopWaitH(cp, VP(y * 8), HP(-4));
       CopInsSet32(location, label);
       chunky[y] = CopSetColor(cp, 1, 0);

--- a/effects/tilezoomer/tilezoomer.c
+++ b/effects/tilezoomer/tilezoomer.c
@@ -37,7 +37,7 @@ static BitmapT *screen1;
 #endif
 static int active = 0;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH + SHADOW];
+static CopInsPairT *bplptr;
 
 /* for each tile following array stores source and destination offsets relative
  * to the beginning of a bitplane */
@@ -151,11 +151,11 @@ static void Init(void) {
   cp = NewCopList(100);
   CopInit(cp);
 #if MOTIONBLUR
-  CopSetupBitplanes(cp, bplptr, screen0, SHADOW);
+  bplptr = CopSetupBitplanes(cp, screen0, SHADOW);
   CopMove16(cp, bpl1mod, MARGIN / 8);
   CopMove16(cp, bpl2mod, MARGIN / 8);
 #else
-  CopSetupBitplanes(cp, bplptr, screen0, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen0, DEPTH);
   /* Screen bitplanes are interleaved! */
   CopMove16(cp, bpl1mod, (WIDTH * (DEPTH - 1) + MARGIN) / 8);
   CopMove16(cp, bpl2mod, (WIDTH * (DEPTH - 1) + MARGIN) / 8);
@@ -265,14 +265,14 @@ static void UpdateBitplanePointers(void) {
 #if MOTIONBLUR
   short j = active;
   for (i = SHADOW - 1; i >= 0; i--) {
-    CopInsSet32(bplptr[i], screen0->planes[j] + offset);
+    CopInsSet32(&bplptr[i], screen0->planes[j] + offset);
     j--;
     if (j < 0)
       j += DEPTH + SHADOW;
   }
 #else
   for (i = 0; i < DEPTH; i++)
-    CopInsSet32(bplptr[i], screen1->planes[i] + offset);
+    CopInsSet32(&bplptr[i], screen1->planes[i] + offset);
 #endif
 }
 

--- a/effects/transparency/transparency.c
+++ b/effects/transparency/transparency.c
@@ -60,7 +60,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   pal = CopLoadColor(cp, 8, 31, 0);
   CopEnd(cp);
 

--- a/effects/turmite/turmite.c
+++ b/effects/turmite/turmite.c
@@ -35,7 +35,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
 

--- a/effects/twister-rgb/twister-rgb.c
+++ b/effects/twister-rgb/twister-rgb.c
@@ -12,12 +12,12 @@
 #define STARTX  96
 
 static CopListT *cp[2];
-static CopInsT *bplptr[2][DEPTH];
+static CopInsPairT *bplptr[2];
 static CopInsT *bplmod[2][HEIGHT];
 static CopInsT *colors[2][HEIGHT];
 static short active = 0;
 
-static CopInsT *sprptr[2][8];
+static CopInsPairT *sprptr[2];
 
 #include "data/twister-gradient.c"
 #include "data/twister-texture.c"
@@ -31,8 +31,8 @@ static void MakeCopperList(CopListT **ptr, short n) {
   short i, j, k;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr[n], &twister, DEPTH);
-  CopSetupSprites(cp, sprptr[n]);
+  bplptr[n] = CopSetupBitplanes(cp, &twister, DEPTH);
+  sprptr[n] = CopSetupSprites(cp);
   CopMove16(cp, dmacon, DMAF_SETCLR|DMAF_RASTER);
   CopSetColor(cp, 0, gradient.colors[0]);
 
@@ -53,10 +53,10 @@ static void MakeCopperList(CopListT **ptr, short n) {
 
   CopEnd(cp);
 
-  CopInsSetSprite(sprptr[n][4], &left[0]);
-  CopInsSetSprite(sprptr[n][5], &left[1]);
-  CopInsSetSprite(sprptr[n][6], &right[0]);
-  CopInsSetSprite(sprptr[n][7], &right[1]);
+  CopInsSetSprite(&sprptr[n][4], &left[0]);
+  CopInsSetSprite(&sprptr[n][5], &left[1]);
+  CopInsSetSprite(&sprptr[n][6], &right[0]);
+  CopInsSetSprite(&sprptr[n][7], &right[1]);
 
   *ptr = cp;
 }
@@ -96,11 +96,11 @@ static void SetupLines(short f) {
   {
     int y = (short)twister.bytesPerRow * y0;
     void **planes = twister.planes;
-    CopInsT **bpl = bplptr[active];
+    CopInsPairT *_bplptr = bplptr[active];
     short n = DEPTH;
 
     while (--n >= 0)
-      CopInsSet32(*bpl++, (*planes++) + y);
+      CopInsSet32(_bplptr++, (*planes++) + y);
   }
 
   /* consecutive lines */

--- a/effects/uvlight/uvlight.c
+++ b/effects/uvlight/uvlight.c
@@ -16,7 +16,7 @@ static u_short active = 0;
 static u_short *shademap;
 static u_short *chunky[2];
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 static u_short *texture;
 
 #include "data/torus-map.c"
@@ -241,10 +241,10 @@ static void ChunkyToPlanar(void) {
       break;
 
     case 12:
-      CopInsSet32(bplptr[0], bpl[3]);
-      CopInsSet32(bplptr[1], bpl[2]);
-      CopInsSet32(bplptr[2], bpl[1]);
-      CopInsSet32(bplptr[3], bpl[0]);
+      CopInsSet32(&bplptr[0], bpl[3]);
+      CopInsSet32(&bplptr[1], bpl[2]);
+      CopInsSet32(&bplptr[2], bpl[1]);
+      CopInsSet32(&bplptr[3], bpl[0]);
       break;
 
     default:
@@ -260,7 +260,7 @@ static void MakeCopperList(CopListT *cp) {
   short i;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadColor(cp, 0, 15, 0);
   for (i = 0; i < HEIGHT * 4; i++) {
     CopWaitSafe(cp, Y(i), 0);

--- a/effects/uvmap-rgb/uvmap-rgb.c
+++ b/effects/uvmap-rgb/uvmap-rgb.c
@@ -14,7 +14,7 @@ static u_short active = 0;
 static u_short *texture;
 static u_short *chunky[2];
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 
 #include "data/texture-rgb.c"
 #include "data/uvmap-rgb.c"
@@ -197,10 +197,10 @@ static void ChunkyToPlanar(void) {
       break;
 
     case 12:
-      CopInsSet32(bplptr[0], bpl[3]);
-      CopInsSet32(bplptr[1], bpl[2]);
-      CopInsSet32(bplptr[2], bpl[1]);
-      CopInsSet32(bplptr[3], bpl[0]);
+      CopInsSet32(&bplptr[0], bpl[3]);
+      CopInsSet32(&bplptr[1], bpl[2]);
+      CopInsSet32(&bplptr[2], bpl[1]);
+      CopInsSet32(&bplptr[3], bpl[0]);
       break;
 
     default:
@@ -216,7 +216,7 @@ static void MakeCopperList(CopListT *cp) {
   short i;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadColor(cp, 0, 15, 0);
   for (i = 0; i < HEIGHT * 4; i++) {
     CopWaitSafe(cp, Y(i), 0);

--- a/effects/uvmap/uvmap.c
+++ b/effects/uvmap/uvmap.c
@@ -14,7 +14,7 @@ static u_short *textureHi, *textureLo;
 static BitmapT *screen[2];
 static u_short active = 0;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 
 #include "data/texture-16-1.c"
 #include "data/gradient.c"
@@ -212,10 +212,10 @@ static void ChunkyToPlanar(void) {
       break;
 
     case 6:
-      CopInsSet32(bplptr[0], bpl[2]);
-      CopInsSet32(bplptr[1], bpl[3]);
-      CopInsSet32(bplptr[2], bpl[2] + BLTSIZE / 2);
-      CopInsSet32(bplptr[3], bpl[3] + BLTSIZE / 2);
+      CopInsSet32(&bplptr[0], bpl[2]);
+      CopInsSet32(&bplptr[1], bpl[3]);
+      CopInsSet32(&bplptr[2], bpl[2] + BLTSIZE / 2);
+      CopInsSet32(&bplptr[3], bpl[3] + BLTSIZE / 2);
       break;
 
     default:
@@ -230,7 +230,7 @@ static void MakeCopperList(CopListT *cp) {
   short i, j;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   for (j = 0; j < 16; j++)
     CopSetColor(cp, j, *pixels++);
   for (i = 0; i < HEIGHT * 2; i++) {

--- a/effects/weave/weave.c
+++ b/effects/weave/weave.c
@@ -82,7 +82,6 @@ static void MakeCopperList(CopListT *cp, StateT *state) {
   CopMove32(cp, sprpt[7], &stripes3_sprdat);
 
   CopWait(cp, Y(-1), 0);
-
   
   state->sprite = CopMove32(cp, sprpt[0], stripes0_sprdat.data); /* up */
   CopMove32(cp, sprpt[1], stripes1_sprdat.data);

--- a/effects/weave/weave.c
+++ b/effects/weave/weave.c
@@ -29,9 +29,9 @@
 #define O4 224
 
 typedef struct State {
-  CopInsT *sprite;
+  CopInsPairT *sprite;
   /* at the beginning: 4 bitplane pointers and bplcon1 */
-  CopInsT *bar;
+  CopInsPairT *bar;
   /* for each bar moves to bplcon1, bpl1mod and bpl2mod */
   CopInsT *bar_change[4];
   /* for each line five horizontal positions */
@@ -61,8 +61,7 @@ static void MakeCopperList(CopListT *cp, StateT *state) {
   CopInit(cp);
 
   /* Setup initial bitplane pointers. */
-  state->bar = cp->curr;
-  CopMove32(cp, bplpt[0], NULL);
+  state->bar = CopMove32(cp, bplpt[0], NULL);
   CopMove32(cp, bplpt[1], NULL);
   CopMove32(cp, bplpt[2], NULL);
   CopMove32(cp, bplpt[3], NULL);
@@ -84,8 +83,8 @@ static void MakeCopperList(CopListT *cp, StateT *state) {
 
   CopWait(cp, Y(-1), 0);
 
-  state->sprite = cp->curr;
-  CopMove32(cp, sprpt[0], stripes0_sprdat.data); /* up */
+  
+  state->sprite = CopMove32(cp, sprpt[0], stripes0_sprdat.data); /* up */
   CopMove32(cp, sprpt[1], stripes1_sprdat.data);
   CopMove32(cp, sprpt[2], stripes2_sprdat.data); /* down */
   CopMove32(cp, sprpt[3], stripes3_sprdat.data);
@@ -162,16 +161,16 @@ static void UpdateBarState(StateT *state) {
   short bx = w + normfx(SIN(f) * w);
 
   {
-    CopInsT *ins = state->bar;
+    CopInsPairT *ins = state->bar;
 
     short offset = (bx >> 3) & -2;
     short shift = ~bx & 15;
 
     CopInsSet32(&ins[0], bar.planes[0] + offset);
-    CopInsSet32(&ins[2], bar.planes[1] + offset);
-    CopInsSet32(&ins[4], bar.planes[2] + offset);
-    CopInsSet32(&ins[6], bar.planes[3] + offset);
-    CopInsSet16(&ins[8], (shift << 4) | shift);
+    CopInsSet32(&ins[1], bar.planes[1] + offset);
+    CopInsSet32(&ins[2], bar.planes[2] + offset);
+    CopInsSet32(&ins[3], bar.planes[3] + offset);
+    CopInsSet16((CopInsT *)&ins[4], (shift << 4) | shift);
   }
 
   {
@@ -197,18 +196,18 @@ static void UpdateBarState(StateT *state) {
 }
 
 static void UpdateSpriteState(StateT *state) {
-  CopInsT *ins = state->sprite;
+  CopInsPairT *ins = state->sprite;
   int fu = frameCount & 63;
   int fd = (~frameCount) & 63;
 
-  CopInsSet32(ins + 0, stripes0_sprdat.data + fu); /* up */
-  CopInsSet32(ins + 2, stripes1_sprdat.data + fu);
-  CopInsSet32(ins + 4, stripes2_sprdat.data + fd); /* down */
-  CopInsSet32(ins + 6, stripes3_sprdat.data + fd);
-  CopInsSet32(ins + 8, stripes0_sprdat.data + fu); /* up */
-  CopInsSet32(ins + 10, stripes1_sprdat.data + fu);
-  CopInsSet32(ins + 12, stripes2_sprdat.data + fd); /* down */
-  CopInsSet32(ins + 14, stripes3_sprdat.data + fd);
+  CopInsSet32(ins++, stripes0_sprdat.data + fu); /* up */
+  CopInsSet32(ins++, stripes1_sprdat.data + fu);
+  CopInsSet32(ins++, stripes2_sprdat.data + fd); /* down */
+  CopInsSet32(ins++, stripes3_sprdat.data + fd);
+  CopInsSet32(ins++, stripes0_sprdat.data + fu); /* up */
+  CopInsSet32(ins++, stripes1_sprdat.data + fu);
+  CopInsSet32(ins++, stripes2_sprdat.data + fd); /* down */
+  CopInsSet32(ins++, stripes3_sprdat.data + fd);
 }
 
 #define HPOFF(x) HP(x + 32)

--- a/effects/wireframe/wireframe.c
+++ b/effects/wireframe/wireframe.c
@@ -13,7 +13,7 @@ static Object3D *cube;
 static CopListT *cp;
 static BitmapT *screen;
 static u_short active = 0;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
 
 #include "data/wireframe-pal.c"
 #include "data/pilka.c"
@@ -41,7 +41,7 @@ static void Init(void) {
 
   cp = NewCopList(80);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_BLITTER | DMAF_RASTER | DMAF_BLITHOG);
@@ -321,7 +321,7 @@ static void Render(void) {
     short i = active;
 
     while (--n >= 0) {
-      CopInsSet32(bplptr[n], planes[i]);
+      CopInsSet32(&bplptr[n], planes[i]);
       if (i == 0)
         i = DEPTH + 1;
       i--;

--- a/include/copper.h
+++ b/include/copper.h
@@ -35,6 +35,11 @@ typedef union {
 } CopInsT;
 
 typedef struct {
+  CopInsT lo;
+  CopInsT hi;
+} CopInsPairT;
+
+typedef struct {
   CopInsT *curr;
   u_short length;
   u_char  overflow; /* -1 if Vertical Position counter overflowed */
@@ -77,24 +82,24 @@ static inline CopInsT *_CopInsMove16(CopInsT *ins, short reg, short data) {
   return ins;
 }
 
-static inline CopInsT *_CopInsMove32(CopInsT *ins, short reg, int data) {
+static inline CopInsPairT *_CopInsMove32(CopInsT *ins, short reg, int data) {
   *((u_short *)ins)++ = reg + 2;
   *((u_short *)ins)++ = data;
   *((u_short *)ins)++ = reg;
   *((u_short *)ins)++ = swap16(data);
-  return ins;
+  return (CopInsPairT *)ins;
 }
 
 static inline void CopInsSet16(CopInsT *ins, short data) {
   ins->move.data = data;
 }
 
-static inline void CopInsSet32(CopInsT *ins, void *data) {
+static inline void CopInsSet32(CopInsPairT *ins, void *data) {
   asm volatile("movew %0,%2\n"
                "swap  %0\n"
                "movew %0,%1\n"
                : "+d" (data)
-               : "m" (ins[1].move.data), "m" (ins[0].move.data));
+               : "m" (ins->hi.move.data), "m" (ins->lo.move.data));
 }
 
 #define CopMove16(cp, reg, data) _CopMove16((cp), CSREG(reg), (data))
@@ -106,9 +111,9 @@ static inline CopInsT *_CopMove16(CopListT *list, short reg, short data) {
   return pos;
 }
 
-static inline CopInsT *_CopMove32(CopListT *list, short reg, int data) {
-  CopInsT *pos = list->curr;
-  list->curr = _CopInsMove32(list->curr, reg, data);
+static inline CopInsPairT *_CopMove32(CopListT *list, short reg, int data) {
+  CopInsPairT *pos = (CopInsPairT *)list->curr;
+  list->curr = (CopInsT *)_CopInsMove32(list->curr, reg, data);
   return pos;
 }
 
@@ -212,12 +217,12 @@ void CopSetupDisplayWindow(CopListT *list, u_short mode,
                            u_short xs, u_short ys, u_short w, u_short h);
 void CopSetupBitplaneFetch(CopListT *list, u_short mode,
                            u_short xs, u_short w);
-void CopSetupBitplanes(CopListT *list, CopInsT **bplptr,
-                       const BitmapT *bitmap, u_short depth);
+CopInsPairT *CopSetupBitplanes(CopListT *list, const BitmapT *bitmap,
+                               u_short depth);
 void CopSetupBitplaneArea(CopListT *list, u_short mode, u_short depth,
                           const BitmapT *bitmap, short x, short y,
                           const Area2D *area);
-void CopUpdateBitplanes(CopInsT **bplptr, const BitmapT *bitmap, short n);
+void CopUpdateBitplanes(CopInsPairT *bplptr, const BitmapT *bitmap, short n);
 
 static inline CopInsT *CopSetColor(CopListT *list, short i, short value) {
   return CopMove16(list, color[i], value);

--- a/include/copper.h
+++ b/include/copper.h
@@ -60,6 +60,11 @@ static inline void CopEnd(CopListT *list) {
   list->curr = ins;
 }
 
+/* @brief Return a pointer to the current copper instruction pointer. */
+static inline void *CopInsPtr(CopListT *list) {
+  return list->curr;
+}
+
 /* @brief Enable copper and activate copper list.
  * @warning This function busy-waits for vertical blank. */
 void CopListActivate(CopListT *list);

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -107,11 +107,11 @@ void EndSprite(SprDataT **datp);
 /* Don't call it for null sprites. */
 void SpriteUpdatePos(SpriteT *spr, u_short hstart, u_short vstart);
 
-void CopSetupSprites(CopListT *list, CopInsT **sprptr);
+CopInsPairT *CopSetupSprites(CopListT *list);
 
 void ResetSprites(void);
 
-static inline void CopInsSetSprite(CopInsT *sprptr, SpriteT *spr) {
+static inline void CopInsSetSprite(CopInsPairT *sprptr, SpriteT *spr) {
   CopInsSet32(sprptr, spr->sprdat);
 }
 

--- a/intro/growing-tree.c
+++ b/intro/growing-tree.c
@@ -18,9 +18,9 @@ extern TrackT TreeVariant;
 extern TrackT TreeFade;
 
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
+static CopInsPairT *bplptr;
+static CopInsPairT *sprptr;
 static BitmapT *screen;
-static CopInsT *sprptr[8];
 
 static u_short nrPal = 0;
 
@@ -199,8 +199,8 @@ static void Init(void) {
 
   cp = NewCopList(50);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
-  CopSetupSprites(cp, sprptr);
+  bplptr = CopSetupBitplanes(cp, screen, DEPTH);
+  sprptr = CopSetupSprites(cp);
   CopEnd(cp);
 
   CopListActivate(cp);
@@ -495,7 +495,7 @@ static void Render(void) {
     GreetsNextTrack();
 
     for (i = 0; i < NSPRITES; i++)
-      CopInsSetSprite(sprptr[i], &grass[i]);
+      CopInsSetSprite(&sprptr[i], &grass[i]);
 
     MakeBranch(WIDTH / 2, HEIGHT - fruit_height / 2 - 1);
   }

--- a/intro/logo.c
+++ b/intro/logo.c
@@ -55,7 +55,7 @@ static void SharedInit(bool out) {
 
   cp = NewCopList(40);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 
   CopListActivate(cp);

--- a/intro/textscroll.c
+++ b/intro/textscroll.c
@@ -16,10 +16,9 @@
 
 static __code short active = 0;
 
-typedef CopInsT *CopInsPtrT;
 
 static CopListT *cp[2];
-static CopInsPtrT (*linebpl)[2][HEIGHT];
+static CopInsPairT *(*linebpl)[2][HEIGHT];
 static BitmapT *scroll;
 
 static __code short last_line = -1;
@@ -29,10 +28,10 @@ extern uint8_t Text[];
 
 #include "data/text-scroll-font.c"
 
-static CopListT *MakeCopperList(CopInsPtrT *linebpl) {
+static CopListT *MakeCopperList(CopInsPairT **linebpl) {
   CopListT *cp = NewCopList(100 + 3 * HEIGHT);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, scroll, DEPTH);
+  CopSetupBitplanes(cp, scroll, DEPTH);
   {
     void *ptr = scroll->planes[0];
     short y;
@@ -60,7 +59,7 @@ static void Init(void) {
   SetupPlayfield(MODE_HIRES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
   LoadPalette(&font_pal, 0);
 
-  linebpl = MemAlloc(sizeof(CopInsPtrT) * 2 * HEIGHT, MEMF_PUBLIC);
+  linebpl = MemAlloc(sizeof(CopInsPairT *) * 2 * HEIGHT, MEMF_PUBLIC);
   cp[0] = MakeCopperList((*linebpl)[0]);
   cp[1] = MakeCopperList((*linebpl)[1]);
 
@@ -101,7 +100,7 @@ static void RenderLine(u_char *dst, char *line, short size) {
 }
 
 static void SetupLinePointers(void) {
-  CopInsT **ins = (*linebpl)[active];
+  CopInsPairT **ins = (*linebpl)[active];
   void *plane = scroll->planes[0];
   int stride = scroll->bytesPerRow;
   int bplsize = scroll->bplSize;

--- a/intro/tilemover.c
+++ b/intro/tilemover.c
@@ -41,7 +41,7 @@ static __code BitmapT *screen;
 static __code int active = 0;
 static __code const PaletteT *currPal;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH + 1];
+static CopInsPairT *bplptr;
 
 /* 1 bit version of logo for blitting */
 static BitmapT *logo_blit;
@@ -229,7 +229,7 @@ static void UpdateBitplanePointers(void) {
   short j = active;
 
   for (i = DEPTH - 1; i >= 0; i--) {
-    CopInsSet32(bplptr[i], screen->planes[j] + offset);
+    CopInsSet32(&bplptr[i], screen->planes[j] + offset);
     j--;
     if (j < 0)
       j += DEPTH + 1;
@@ -289,7 +289,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen, DEPTH);
+  bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   CopMove16(cp, bpl1mod, (WIDTH - S_WIDTH) / 8);
   CopMove16(cp, bpl2mod, (WIDTH - S_WIDTH) / 8);
   CopEnd(cp);

--- a/intro/turmite.c
+++ b/intro/turmite.c
@@ -606,7 +606,7 @@ static void Init(void) {
 
   cp = NewCopList(100);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
   CopListActivate(cp);
 

--- a/intro/uvmap.c
+++ b/intro/uvmap.c
@@ -25,8 +25,8 @@ static __code u_short active = 0;
 static __code volatile short c2p_phase;
 static __code void **c2p_bpl;
 static CopListT *cp;
-static CopInsT *bplptr[DEPTH];
-static CopInsT *sprptr[8];
+static CopInsPairT *bplptr;
+static CopInsPairT *sprptr;
 
 #include "data/electric-small.c"
 #include "data/texture-inside.c"
@@ -323,10 +323,10 @@ static void ChunkyToPlanar(void) {
       break;
 
     case 6:
-      CopInsSet32(bplptr[0], bpl[2]);
-      CopInsSet32(bplptr[1], bpl[3]);
-      CopInsSet32(bplptr[2], bpl[2] + BLTSIZE / 2);
-      CopInsSet32(bplptr[3], bpl[3] + BLTSIZE / 2);
+      CopInsSet32(&bplptr[0], bpl[2]);
+      CopInsSet32(&bplptr[1], bpl[3]);
+      CopInsSet32(&bplptr[2], bpl[2] + BLTSIZE / 2);
+      CopInsSet32(&bplptr[3], bpl[3] + BLTSIZE / 2);
       break;
 
     default:
@@ -340,8 +340,8 @@ static void MakeCopperList(CopListT *cp, short *pixels) {
   short i, j;
 
   CopInit(cp);
-  CopSetupBitplanes(cp, bplptr, screen[active], DEPTH);
-  CopSetupSprites(cp, sprptr);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
+  sprptr = CopSetupSprites(cp);
   for (j = 0; j < 16; j++)
     CopSetColor(cp, j, *pixels++);
   for (i = 0; i < HEIGHT * 2; i++) {
@@ -404,7 +404,7 @@ static void Init(short var) {
     for (i = 0; i < electric_sprites; i++) {
       short hp = X(i * 16 + (320 - electric_sprites * 16) / 2);
       SpriteUpdatePos(&electric[i], hp, Y((256 - electric_height) / 2));
-      CopInsSetSprite(sprptr[i], &electric[i]);
+      CopInsSetSprite(&sprptr[i], &electric[i]);
     }
 
     LoadPalette(&electric_pal, 16);

--- a/intro/vitruvian.c
+++ b/intro/vitruvian.c
@@ -46,7 +46,7 @@ static void Init(void) {
 
   cp = NewCopList(40);
   CopInit(cp);
-  CopSetupBitplanes(cp, NULL, screen, DEPTH);
+  CopSetupBitplanes(cp, screen, DEPTH);
   CopEnd(cp);
 
   CopListActivate(cp);

--- a/intro/weave.c
+++ b/intro/weave.c
@@ -53,7 +53,7 @@ typedef struct StateBar {
 typedef struct StateFull {
   StateBarT bars;
   CopListT *cp;
-  CopInsT *sprite;
+  CopInsPairT *sprite;
   /* for each line five horizontal positions */
   short ampl;
   u_short *stripes[HEIGHT];
@@ -96,7 +96,7 @@ static void MakeCopperListFull(StateFullT *state) {
 
   CopWait(cp, Y(-1), 0);
 
-  state->sprite = cp->curr;
+  state->sprite = CopInsPtr(cp);
   for (i = 0; i < NSPRITES; i++)
     CopMove32(cp, sprpt[i], stripe[i].sprdat->data);
 
@@ -243,7 +243,7 @@ static void UpdateBarState(StateBarT *bars) {
         offset += bar_bytesPerRow * 33;
 
       for (j = 0; j < DEPTH; j++, ins += 2)
-        CopInsSet32(ins, bar.planes[j] + offset);
+        CopInsSet32((CopInsPairT *)ins, bar.planes[j] + offset);
       CopInsSet16(ins, (shift << 4) | shift);
     }
 
@@ -252,13 +252,13 @@ static void UpdateBarState(StateBarT *bars) {
 }
 
 static void UpdateSpriteState(StateFullT *state) {
-  CopInsT *ins = state->sprite;
+  CopInsPairT *ins = state->sprite;
   int t = frameCount * 2;
   int fu = t & 63;
   int fd = ~t & 63;
   short i;
 
-  for (i = 0; i < NSPRITES; i++, ins += 2)
+  for (i = 0; i < NSPRITES; i++, ins++)
     CopInsSet32(ins, stripe[i].sprdat->data + ((i & 2) ? fd : fu));
 }
 

--- a/lib/libgfx/CopSetupBitplanes.c
+++ b/lib/libgfx/CopSetupBitplanes.c
@@ -1,29 +1,26 @@
 #include <copper.h>
 
 CopInsPairT *CopSetupBitplanes(CopListT *list, const BitmapT *bitmap,
-                               u_short depth) 
+                               u_short depth)
 {
   CopInsPairT *bplptr = CopInsPtr(list);
 
+  short modulo = 0;
+  short n = depth - 1;
+
+  if (bitmap->flags & BM_INTERLEAVED)
+    modulo = (short)bitmap->bytesPerRow * n;
+
   {
     void **planes = bitmap->planes;
-    short n = depth - 1;
-    short i = 0;
+    int i = 0;
 
     do {
       CopMove32(list, bplpt[i++], *planes++);
     } while (--n != -1);
   }
 
-  {
-    short modulo = 0;
-
-    if (bitmap->flags & BM_INTERLEAVED)
-      modulo = (short)bitmap->bytesPerRow * (short)(depth - 1);
-
-    CopMove16(list, bpl1mod, modulo);
-    CopMove16(list, bpl2mod, modulo);
-  }
-
+  CopMove16(list, bpl1mod, modulo);
+  CopMove16(list, bpl2mod, modulo);
   return bplptr;
 }

--- a/lib/libgfx/CopSetupBitplanes.c
+++ b/lib/libgfx/CopSetupBitplanes.c
@@ -1,18 +1,20 @@
 #include <copper.h>
 
-void CopSetupBitplanes(CopListT *list, CopInsT **bplptr,
-                       const BitmapT *bitmap, u_short depth) 
+CopInsPairT *CopSetupBitplanes(CopListT *list, const BitmapT *bitmap,
+                               u_short depth) 
 {
+  CopInsPairT *bplptr = NULL;
+
   {
     void **planes = bitmap->planes;
     short n = depth - 1;
     short i = 0;
 
     do {
-      CopInsT *ins = CopMove32(list, bplpt[i++], *planes++);
+      CopInsPairT *ins = CopMove32(list, bplpt[i++], *planes++);
 
-      if (bplptr)
-        *bplptr++ = ins;
+      if (!bplptr)
+        bplptr = ins;
     } while (--n != -1);
   }
 
@@ -25,4 +27,6 @@ void CopSetupBitplanes(CopListT *list, CopInsT **bplptr,
     CopMove16(list, bpl1mod, modulo);
     CopMove16(list, bpl2mod, modulo);
   }
+
+  return bplptr;
 }

--- a/lib/libgfx/CopSetupBitplanes.c
+++ b/lib/libgfx/CopSetupBitplanes.c
@@ -3,7 +3,7 @@
 CopInsPairT *CopSetupBitplanes(CopListT *list, const BitmapT *bitmap,
                                u_short depth) 
 {
-  CopInsPairT *bplptr = NULL;
+  CopInsPairT *bplptr = CopInsPtr(list);
 
   {
     void **planes = bitmap->planes;
@@ -11,10 +11,7 @@ CopInsPairT *CopSetupBitplanes(CopListT *list, const BitmapT *bitmap,
     short i = 0;
 
     do {
-      CopInsPairT *ins = CopMove32(list, bplpt[i++], *planes++);
-
-      if (!bplptr)
-        bplptr = ins;
+      CopMove32(list, bplpt[i++], *planes++);
     } while (--n != -1);
   }
 

--- a/lib/libgfx/CopSetupSprites.c
+++ b/lib/libgfx/CopSetupSprites.c
@@ -2,14 +2,11 @@
 
 CopInsPairT *CopSetupSprites(CopListT *list) {
   SprDataT *spr = NullSprData;
-  CopInsPairT *sprptr = NULL;
+  CopInsPairT *sprptr = CopInsPtr(list);
   short i;
 
-  for (i = 0; i < 8; i++) {
-    CopInsPairT *ins = CopMove32(list, sprpt[i], spr);
-    if (!sprptr)
-      sprptr = ins;
-  }
+  for (i = 0; i < 8; i++)
+    CopMove32(list, sprpt[i], spr);
 
   return sprptr;
 }

--- a/lib/libgfx/CopSetupSprites.c
+++ b/lib/libgfx/CopSetupSprites.c
@@ -1,12 +1,15 @@
 #include <sprite.h>
 
-void CopSetupSprites(CopListT *list, CopInsT **sprptr) {
+CopInsPairT *CopSetupSprites(CopListT *list) {
   SprDataT *spr = NullSprData;
+  CopInsPairT *sprptr = NULL;
   short i;
 
   for (i = 0; i < 8; i++) {
-    CopInsT *ins = CopMove32(list, sprpt[i], spr);
-    if (sprptr)
-      *sprptr++ = ins;
+    CopInsPairT *ins = CopMove32(list, sprpt[i], spr);
+    if (!sprptr)
+      sprptr = ins;
   }
+
+  return sprptr;
 }

--- a/lib/libgfx/CopSetupSprites.c
+++ b/lib/libgfx/CopSetupSprites.c
@@ -3,10 +3,11 @@
 CopInsPairT *CopSetupSprites(CopListT *list) {
   SprDataT *spr = NullSprData;
   CopInsPairT *sprptr = CopInsPtr(list);
-  short i;
+  short n = 8;
+  int i = 0;
 
-  for (i = 0; i < 8; i++)
-    CopMove32(list, sprpt[i], spr);
+  while (--n >= 0)
+    CopMove32(list, sprpt[i++], spr);
 
   return sprptr;
 }

--- a/lib/libgfx/CopUpdateBitplanes.c
+++ b/lib/libgfx/CopUpdateBitplanes.c
@@ -1,8 +1,8 @@
 #include <copper.h>
 
-void CopUpdateBitplanes(CopInsT **bplptr, const BitmapT *bitmap, short n) {
+void CopUpdateBitplanes(CopInsPairT *bplptr, const BitmapT *bitmap, short n) {
   void **planes = bitmap->planes;
 
   while (--n >= 0)
-    CopInsSet32(*bplptr++, *planes++);
+    CopInsSet32(bplptr++, *planes++);
 }


### PR DESCRIPTION
Make it simpler to use copper instructions that write pointers to bplpt & sprpt registers.