### PR TITLE
Clean up CopList interface

### DIFF
--- a/effects/anim-polygons/anim-polygons.c
+++ b/effects/anim-polygons/anim-polygons.c
@@ -25,8 +25,8 @@ static short maybeSkipFrame = 0;
 /* Reading polygon data */
 static short current_frame = 0;
 
-static void MakeCopperList(CopListT *cp) {
-  CopInit(cp);
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(100 + gradient.height * (gradient.width + 1));
   bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   {
     short *pixels = gradient.pixels;
@@ -37,7 +37,7 @@ static void MakeCopperList(CopListT *cp) {
       for (j = 0; j < 16; j++) CopSetColor(cp, j, *pixels++);
     }
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -46,8 +46,7 @@ static void Init(void) {
   BitmapClear(screen);
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(YOFF), WIDTH, HEIGHT);
-  cp = NewCopList(100 + gradient.height * (gradient.width + 1));
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/anim/anim.c
+++ b/effects/anim/anim.c
@@ -23,18 +23,12 @@ typedef struct {
 #include "data/running-pal.c"
 #include "data/running.c"
 
-static void Load(void) {
-  screen = NewBitmap(WIDTH, HEIGHT, DEPTH + 1, BM_CLEAR);
+static void Init(void) {
+  screen = NewBitmap(WIDTH, HEIGHT, DEPTH + 1, 0);
 
   Log("Animation has %d frames %d x %d.\n", 
       running.count, running.width, running.height);
-}
 
-static void UnLoad(void) {
-  DeleteBitmap(screen);
-}
-
-static void Init(void) {
   EnableDMA(DMAF_BLITTER);
   BitmapClear(screen);
 
@@ -42,10 +36,8 @@ static void Init(void) {
   LoadPalette(&running_pal, 0);
 
   cp = NewCopList(100);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
-
+  CopListFinish(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }
@@ -54,6 +46,7 @@ static void Kill(void) {
   DisableDMA(DMAF_COPPER | DMAF_RASTER | DMAF_BLITTER);
 
   DeleteCopList(cp);
+  DeleteBitmap(screen);
 }
 
 static void DrawSpans(u_char *bpl) {
@@ -109,4 +102,4 @@ static void Render(void) {
   active = (active + 1) % (DEPTH + 1);
 }
 
-EFFECT(Anim, Load, UnLoad, Init, Kill, Render, NULL);
+EFFECT(Anim, NULL, NULL, Init, Kill, Render, NULL);

--- a/effects/ball/ball.c
+++ b/effects/ball/ball.c
@@ -79,18 +79,11 @@ static void MakeUVMapRenderCode(void) {
   *code++ = 0x4e75; /* rts */
 }
 
-static void MakeCopperList(CopListT *cp) {
-  CopInit(cp);
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(80);
   CopSetupBitplanes(cp, &background, S_DEPTH);
   sprptr = CopSetupSprites(cp);
-  CopEnd(cp);
-
-  {
-    short i;
-
-    for (i = 0; i < 8; i++)
-      CopInsSetSprite(&sprptr[i], &sprite[active][i]);
-  }
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -127,9 +120,15 @@ static void Init(void) {
   LoadPalette(&background_pal, 0);
   LoadPalette(&texture_pal, 16);
 
-  cp = NewCopList(80);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
+
+  {
+    short i;
+
+    for (i = 0; i < 8; i++)
+      CopInsSetSprite(&sprptr[i], &sprite[active][i]);
+  }
 
   EnableDMA(DMAF_RASTER | DMAF_SPRITE);
 }

--- a/effects/blurred/blurred.c
+++ b/effects/blurred/blurred.c
@@ -25,10 +25,10 @@ static CopListT *cp;
 
 static short iterCount = 0;
 
-static void MakeCopperList(CopListT *cp) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(200);
   short i;
 
-  CopInit(cp);
   bplptr[0] = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopWait(cp, Y(-18), 0);
   CopLoadPal(cp, &blurred_1_pal, 0);
@@ -43,7 +43,7 @@ static void MakeCopperList(CopListT *cp) {
     if (bplptr[1])
       bplptr[1] = ins;
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -70,8 +70,7 @@ static void Init(void) {
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
 
-  cp = NewCopList(200);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/blurred3d/blurred3d.c
+++ b/effects/blurred3d/blurred3d.c
@@ -35,8 +35,8 @@ static void UnLoad(void) {
   ResetMesh3D(mesh);
 }
 
-static void MakeCopperList(CopListT *cp) {
-  CopInit(cp);
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(80 + gradient.height * (gradient.width + 1));
   bplptr = CopSetupBitplanes(cp, screen[0], DEPTH);
 
   {
@@ -62,7 +62,7 @@ static void MakeCopperList(CopListT *cp) {
     }
   }
 
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -78,8 +78,7 @@ static void Init(void) {
 
   SetupPlayfield(MODE_LORES, DEPTH, X(STARTX), Y(STARTY), WIDTH, HEIGHT * 5 / 4);
 
-  cp = NewCopList(80 + gradient.height * (gradient.width + 1));
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/bobs3d/bobs3d.c
+++ b/effects/bobs3d/bobs3d.c
@@ -21,11 +21,11 @@ static int active = 0;
 
 static Mesh3D *mesh = &pilka;
 
-static void MakeCopperList(CopListT *cp) {
-  CopInit(cp);
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(80);
   CopWait(cp, Y(-1), 0);
   bplptr = CopSetupBitplanes(cp, screen[1], DEPTH);
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -38,8 +38,7 @@ static void Init(void) {
   SetupPlayfield(MODE_LORES, DEPTH, X(32), Y(0), WIDTH, HEIGHT);
   LoadPalette(&bobs_pal, 0);
 
-  cp = NewCopList(80);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_BLITHOG);
 }

--- a/effects/bumpmap-rgb/bumpmap-rgb.c
+++ b/effects/bumpmap-rgb/bumpmap-rgb.c
@@ -265,10 +265,10 @@ static void ChunkyToPlanar(void) {
   ClearIRQ(INTF_BLIT);
 }
 
-static void MakeCopperList(CopListT *cp) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(1200);
   short i;
 
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadColor(cp, 0, 15, 0);
   for (i = 0; i < HEIGHT * 4; i++) {
@@ -279,7 +279,7 @@ static void MakeCopperList(CopListT *cp) {
     /* Alternating shift by one for bitplane data. */
     CopMove16(cp, bplcon1, (i & 1) ? 0x0022 : 0x0000);
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -299,8 +299,7 @@ static void Init(void) {
   custom->bpldat[4] = 0x7777; // rgbb: 0111
   custom->bpldat[5] = 0xcccc; // rgbb: 1100
 
-  cp = NewCopList(1200);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/effects/butterfly-gears/butterfly-gears.c
+++ b/effects/butterfly-gears/butterfly-gears.c
@@ -102,8 +102,6 @@ static void InitCopperListBall(CopListT *cp, int y, int yInc) {
 
 static void MakeBallCopperList(BallCopListT *ballCp) {
   CopListT *cp = NewCopList(INSTRUCTIONS_PER_BALL * 2 + 100);
-  ballCp->cp = cp;
-  CopInit(cp);
   CopMove16(cp, dmacon, DMAF_SETCLR | DMAF_RASTER);
   CopLoadPal(cp, &testscreen_pal, 0);
   CopSetupBitplanes(cp, &testscreen, testscreen.depth);
@@ -117,7 +115,7 @@ static void MakeBallCopperList(BallCopListT *ballCp) {
   ballCp->lowestBallCopper = cp->curr;
   InitCopperListBall(cp, Y0 + 166, 1);
 
-  CopEnd(cp);
+  ballCp->cp = CopListFinish(cp);
 }
 
 static void Init(void) {

--- a/effects/circles/circles.c
+++ b/effects/circles/circles.c
@@ -11,15 +11,14 @@ static CopListT *cp;
 
 static void Init(void) {
   screen = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
-  cp = NewCopList(100);
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
   SetColor(0, 0x000);
   SetColor(1, 0xfff);
 
-  CopInit(cp);
+  cp = NewCopList(100);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);

--- a/effects/credits/credits.c
+++ b/effects/credits/credits.c
@@ -9,7 +9,7 @@
 #define DEPTH 4
 
 static BitmapT *foreground;
-static CopListT *cp0, *cp1;
+static CopListT *cp[2];
 static const BitmapT *lower;
 static const PaletteT *lower_pal;
 static Point2D lower_pos;
@@ -122,17 +122,17 @@ static void Init(void) {
 
   lower = NULL;
 
-  cp0 = NewCopList(300);
-  cp1 = NewCopList(300);
-  MakeCopperList(cp0);
-  CopListActivate(cp0);
+  cp[0] = NewCopList(300);
+  cp[1] = NewCopList(300);
+  MakeCopperList(cp[0]);
+  CopListActivate(cp[0]);
   EnableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_BLITHOG);
 }
 
 static void Kill(void) {
   DisableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_BLITHOG);
-  DeleteCopList(cp0);
-  DeleteCopList(cp1);
+  DeleteCopList(cp[0]);
+  DeleteCopList(cp[1]);
   DeleteBitmap(foreground);
 }
 
@@ -180,10 +180,10 @@ static void Render(void) {
       lower = NULL;
   }
 
-  MakeCopperList(cp1);
-  CopListRun(cp1);
+  MakeCopperList(cp[1]);
+  CopListRun(cp[1]);
   TaskWaitVBlank();
-  swapr(cp0, cp1);
+  { CopListT *tmp = cp[0]; cp[0] = cp[1]; cp[1] = tmp; }
 }
 
 EFFECT(Credits, NULL, NULL, Init, Kill, Render, NULL);

--- a/effects/credits/credits.c
+++ b/effects/credits/credits.c
@@ -53,7 +53,7 @@ static const BitmapT *member[5] = {
 #define FLOOR_Y Y(64)
 
 static void MakeCopperList(CopListT *cp) {
-  CopInit(cp);
+  CopListReset(cp);
   CopSetupDisplayWindow(cp, MODE_LORES, X(0), Y(0), 320, 256); 
   CopMove16(cp, dmacon, DMAF_RASTER);
 
@@ -112,7 +112,7 @@ static void MakeCopperList(CopListT *cp) {
     CopMove16(cp, dmacon, DMAF_RASTER);
   }
 
-  CopEnd(cp);
+  CopListFinish(cp);
 }
 
 static void Init(void) {

--- a/effects/credits/credits.c
+++ b/effects/credits/credits.c
@@ -14,6 +14,7 @@ static const BitmapT *lower;
 static const PaletteT *lower_pal;
 static Point2D lower_pos;
 static Area2D lower_area;
+static short active = 0;
 
 /* 'credits_logo' and 'txt_*' must have empty 16 pixels on the left and on the
  * right. Otherwise Display Data Fetcher will show some artifact when image
@@ -180,10 +181,10 @@ static void Render(void) {
       lower = NULL;
   }
 
-  MakeCopperList(cp[1]);
-  CopListRun(cp[1]);
+  MakeCopperList(cp[active]);
+  CopListRun(cp[active]);
   TaskWaitVBlank();
-  { CopListT *tmp = cp[0]; cp[0] = cp[1]; cp[1] = tmp; }
+  active ^= 1;
 }
 
 EFFECT(Credits, NULL, NULL, Init, Kill, Render, NULL);

--- a/effects/flatshade-convex/flatshade-convex.c
+++ b/effects/flatshade-convex/flatshade-convex.c
@@ -41,9 +41,8 @@ static void Init(void) {
   LoadPalette(&flatshade_pal, 0);
 
   cp = NewCopList(80);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[0], DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_BLITTER | DMAF_RASTER | DMAF_BLITHOG);
 }

--- a/effects/flatshade/flatshade.c
+++ b/effects/flatshade/flatshade.c
@@ -40,9 +40,8 @@ static void Init(void) {
   LoadPalette(&flatshade_pal, 0);
 
   cp = NewCopList(80);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[0], DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_BLITTER | DMAF_RASTER | DMAF_BLITHOG);
 }

--- a/effects/floor-old/floor-old.c
+++ b/effects/floor-old/floor-old.c
@@ -86,11 +86,11 @@ static void Load(void) {
   ITER(i, 0, 255, cycleStart[i] = random() & 63);
 }
 
-static void MakeCopperList(CopListT *cp, short num) {
+static CopListT *MakeCopperList(short num) {
+  CopListT *cp = NewCopList((HEIGHT - FAR_Y) * STRIDE / sizeof(CopInsT) + 300);
   CopInsT *ins;
   short i, j;
 
-  CopInit(cp);
   CopSetupBitplanes(cp, screen[num], DEPTH);
   CopLoadColor(cp, 0, 3, 0);
 
@@ -115,7 +115,7 @@ static void MakeCopperList(CopListT *cp, short num) {
 
   CopWait(cp, Y(i) & 255, 0);
   CopLoadColor(cp, 0, 3, 0);
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -137,11 +137,8 @@ static void Init(void) {
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
 
-  cp[0] = NewCopList((HEIGHT - FAR_Y) * STRIDE / sizeof(CopInsT) + 300);
-  cp[1] = NewCopList((HEIGHT - FAR_Y) * STRIDE / sizeof(CopInsT) + 300);
-
-  MakeCopperList(cp[0], 0);
-  MakeCopperList(cp[1], 1);
+  cp[0] = MakeCopperList(0);
+  cp[1] = MakeCopperList(1);
   CopListActivate(cp[active]);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/floor/floor.c
+++ b/effects/floor/floor.c
@@ -66,10 +66,10 @@ static void GenerateShifterValues(void) {
   }
 }
 
-static void MakeCopperList(CopListT *cp, short n) {
+static CopListT *MakeCopperList(short n) {
+  CopListT *cp = NewCopList(100 + 2 * HEIGHT + 15 * HEIGHT / 8);
   short i;
 
-  CopInit(cp);
   CopSetupBitplanes(cp, &floor, DEPTH);
 
   for (i = 0; i < HEIGHT; i++) {
@@ -84,7 +84,7 @@ static void MakeCopperList(CopListT *cp, short n) {
     }
   }
 
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void InitStripes(void) {
@@ -109,11 +109,8 @@ static void Init(void) {
   SetupBitplaneFetch(MODE_LORES, X(-16), WIDTH + 16);
   SetColor(0, 0);
 
-  coplist[0] = NewCopList(100 + 2 * HEIGHT + 15 * HEIGHT / 8);
-  coplist[1] = NewCopList(100 + 2 * HEIGHT + 15 * HEIGHT / 8);
-
-  MakeCopperList(coplist[0], 0);
-  MakeCopperList(coplist[1], 1);
+  coplist[0] = MakeCopperList(0);
+  coplist[1] = MakeCopperList(1);
 
   CopListActivate(coplist[active ^ 1]);
   EnableDMA(DMAF_RASTER);

--- a/effects/floor/floor.c
+++ b/effects/floor/floor.c
@@ -18,10 +18,9 @@
 #define HEIGHT 256
 #define DEPTH 4
 
-static CopListT *coplist[2];
-static short active = 0;
-
+static CopListT *cp[2];
 static CopInsT *copLine[2][HEIGHT];
+static short active = 0;
 
 /* A struct that controls stripe's colors */
 typedef struct {
@@ -66,7 +65,7 @@ static void GenerateShifterValues(void) {
   }
 }
 
-static CopListT *MakeCopperList(short n) {
+static CopListT *MakeCopperList(CopInsT **line) {
   CopListT *cp = NewCopList(100 + 2 * HEIGHT + 15 * HEIGHT / 8);
   short i;
 
@@ -74,7 +73,7 @@ static CopListT *MakeCopperList(short n) {
 
   for (i = 0; i < HEIGHT; i++) {
     CopWait(cp, Y(i), 0);
-    copLine[n][i] = CopMove16(cp, bplcon1, 0);
+    line[i] = CopMove16(cp, bplcon1, 0);
 
     if ((i & 7) == 0) {
       short j;
@@ -109,17 +108,17 @@ static void Init(void) {
   SetupBitplaneFetch(MODE_LORES, X(-16), WIDTH + 16);
   SetColor(0, 0);
 
-  coplist[0] = MakeCopperList(0);
-  coplist[1] = MakeCopperList(1);
+  cp[0] = MakeCopperList(copLine[0]);
+  cp[1] = MakeCopperList(copLine[1]);
 
-  CopListActivate(coplist[active ^ 1]);
+  CopListActivate(cp[active ^ 1]);
   EnableDMA(DMAF_RASTER);
 }
 
 static void Kill(void) {
   DisableDMA(DMAF_RASTER);
-  DeleteCopList(coplist[0]);
-  DeleteCopList(coplist[1]);
+  DeleteCopList(cp[0]);
+  DeleteCopList(cp[1]);
 }
 
 /* Shift colors by an offset */
@@ -251,7 +250,7 @@ static void Render(void) {
   }
   ProfilerStop(Floor);
 
-  CopListRun(coplist[active]);
+  CopListRun(cp[active]);
   TaskWaitVBlank();
   active ^= 1;
 }

--- a/effects/game-of-life/game-of-life.c
+++ b/effects/game-of-life/game-of-life.c
@@ -311,10 +311,10 @@ static void ChangePalette(const u_short* pal) {
     }
 }
 
-static void MakeCopperList(CopListT *cp) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(800);
   short i;
 
-  CopInit(cp);
   // initially previous states are empty
   // save addresses of these instructions to change bitplane
   // order when new state gets generated
@@ -333,7 +333,7 @@ static void MakeCopperList(CopListT *cp) {
     CopMove16(cp, bpl2mod, 0);
     CopWaitSafe(cp, Y(i + 1), 0);
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void UpdateBitplanePointers(void) {
@@ -428,8 +428,7 @@ static void Init(void) {
   WaitBlitter();
   ClearIRQ(INTF_BLIT);
 
-  cp = NewCopList(800);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
 
 #ifdef DEBUG_KBD

--- a/effects/glitch/glitch.c
+++ b/effects/glitch/glitch.c
@@ -47,9 +47,20 @@ static void BitplaneCopyFast(BitmapT *dst, short d, u_short x, u_short y,
   custom->bltsize = bltsize;
 }
 
-static void Init(void) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(100 + HEIGHT * 2);
   short i;
 
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
+  for (i = 0; i < HEIGHT; i++) {
+    CopWait(cp, Y(YSTART + i), 0);
+    /* Alternating shift by one for bitplane data. */
+    line[i] = CopMove16(cp, bplcon1, 0);
+  }
+  return CopListFinish(cp);
+}
+
+static void Init(void) {
   screen[0] = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
   screen[1] = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
 
@@ -63,16 +74,7 @@ static void Init(void) {
   SetColor(6, 0xFF0);
   SetColor(7, 0xFFF);
 
-  cp = NewCopList(100 + HEIGHT * 2);
-  CopInit(cp);
-  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
-  for (i = 0; i < HEIGHT; i++) {
-    CopWait(cp, Y(YSTART + i), 0);
-    /* Alternating shift by one for bitplane data. */
-    line[i] = CopMove16(cp, bplcon1, 0);
-  }
-  CopEnd(cp);
-
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER | DMAF_BLITTER);
 }

--- a/effects/growing-tree/growing-tree.c
+++ b/effects/growing-tree/growing-tree.c
@@ -152,9 +152,8 @@ static void Init(void) {
   GreetsInit();
 
   cp = NewCopList(50);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER | DMAF_BLITTER);

--- a/effects/gui/gui.c
+++ b/effects/gui/gui.c
@@ -14,7 +14,6 @@
 
 static BitmapT *screen;
 static CopListT *cp;
-static CopInsPairT *sprptr;
 
 #include "data/toggle_0.c"
 #include "data/toggle_1.c"
@@ -59,6 +58,16 @@ static void Load(void) {
   GuiInit(gui, &font);
 }
 
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(120);
+  CopInsPairT *sprptr = CopSetupSprites(cp);
+
+  CopSetupBitplanes(cp, screen, DEPTH);
+  CopInsSetSprite(&sprptr[0], &pointer);
+  SpriteUpdatePos(&pointer, X(0), Y(0));
+  return CopListFinish(cp);
+}
+
 static void Init(void) {
   screen = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
 
@@ -72,14 +81,7 @@ static void Init(void) {
   SetColor(UI_FG_ACTIVE, 0x46e);
   LoadPalette(&pointer_pal, 16);
 
-  cp = NewCopList(120);
-  CopSetupBitplanes(cp, screen, DEPTH);
-  sprptr = CopSetupSprites(cp);
-  CopListFinish(cp);
-
-  CopInsSetSprite(&sprptr[0], &pointer);
-  SpriteUpdatePos(&pointer, X(0), Y(0));
-
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   KeyboardInit();

--- a/effects/gui/gui.c
+++ b/effects/gui/gui.c
@@ -73,10 +73,9 @@ static void Init(void) {
   LoadPalette(&pointer_pal, 16);
 
   cp = NewCopList(120);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
   sprptr = CopSetupSprites(cp);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   CopInsSetSprite(&sprptr[0], &pointer);
   SpriteUpdatePos(&pointer, X(0), Y(0));

--- a/effects/highway/highway.c
+++ b/effects/highway/highway.c
@@ -45,8 +45,9 @@ static BitmapT *carry;
 
 static BitmapT *lanes[2];
 
-static void MakeCopperList(CopListT *cp) {
-  CopInit(cp);
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(300);
+
   sprptr = CopSetupSprites(cp);
 
   CopSetupBitplanes(cp, &city_top, DEPTH);
@@ -103,9 +104,7 @@ static void MakeCopperList(CopListT *cp) {
     CopMove16(cp, dmacon, DMAF_SETCLR | DMAF_RASTER);
   }
 
-  CopEnd(cp);
-
-  ITER(i, 0, 7, CopInsSetSprite(&sprptr[i], &sprite[i]));
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -120,13 +119,18 @@ static void Init(void) {
   LoadPalette(&sprite_pal, 24);
   LoadPalette(&sprite_pal, 28);
 
-  cp = NewCopList(300);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_SPRITE);
 
-  ITER(i, 0, 7,
-       SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y(LANEL_Y + LANE_H + 4)));
+  {
+    short i;
+
+    for (i = 0; i < 8; i++) {
+      CopInsSetSprite(&sprptr[i], &sprite[i]);
+      SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y(LANEL_Y + LANE_H + 4));
+    }
+  }
 }
 
 static void Kill(void) {

--- a/effects/highway/highway.c
+++ b/effects/highway/highway.c
@@ -31,8 +31,7 @@ typedef struct {
 static Car cars[CARS];
 
 static CopListT *cp;
-static u_short active = 0;
-static CopInsPairT *sprptr;
+static short active = 0;
 static CopInsPairT *bplptr[2];
 static BitmapT *carry;
 
@@ -47,8 +46,8 @@ static BitmapT *lanes[2];
 
 static CopListT *MakeCopperList(void) {
   CopListT *cp = NewCopList(300);
-
-  sprptr = CopSetupSprites(cp);
+  CopInsPairT *sprptr = CopSetupSprites(cp);
+  short i;
 
   CopSetupBitplanes(cp, &city_top, DEPTH);
   CopWait(cp, Y(-18), 0);
@@ -104,6 +103,11 @@ static CopListT *MakeCopperList(void) {
     CopMove16(cp, dmacon, DMAF_SETCLR | DMAF_RASTER);
   }
 
+  for (i = 0; i < 8; i++) {
+    CopInsSetSprite(&sprptr[i], &sprite[i]);
+    SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y(LANEL_Y + LANE_H + 4));
+  }
+
   return CopListFinish(cp);
 }
 
@@ -122,15 +126,6 @@ static void Init(void) {
   cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_SPRITE);
-
-  {
-    short i;
-
-    for (i = 0; i < 8; i++) {
-      CopInsSetSprite(&sprptr[i], &sprite[i]);
-      SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y(LANEL_Y + LANE_H + 4));
-    }
-  }
 }
 
 static void Kill(void) {

--- a/effects/kbtest/kbtest.c
+++ b/effects/kbtest/kbtest.c
@@ -19,15 +19,14 @@ static FileT *ser;
 
 static void Init(void) {
   screen = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
-  cp = NewCopList(100);
 
   SetupPlayfield(MODE_HIRES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
   SetColor(0, 0x000);
   SetColor(1, 0xfff);
 
-  CopInit(cp);
+  cp = NewCopList(100);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 

--- a/effects/layers/layers.c
+++ b/effects/layers/layers.c
@@ -141,11 +141,10 @@ static void SetupRaster(CopListT *cp) {
 }
 
 static void MakeCopperList(CopListT *cp) {
-
-  CopInit(cp);
+  CopListReset(cp);
   SetupLayers(cp);
   SetupRaster(cp);
-  CopEnd(cp);
+  CopListFinish(cp);
 }
 
 static void Init(void) {

--- a/effects/layers/layers.c
+++ b/effects/layers/layers.c
@@ -13,7 +13,7 @@
 #include "data/bg-gradient.c"
 #include "data/fg-gradient.c"
 
-static CopListT *cp0, *cp1;
+static CopListT *cp[2];
 static short fg_y, bg_y, fg_x, bg_x;
 
 #define bg_bplmod ((background_width - (WIDTH + 16)) / 8)
@@ -156,17 +156,17 @@ static void Init(void) {
   custom->bplcon2 = 0;
 #endif
 
-  cp0 = NewCopList(500);
-  cp1 = NewCopList(500);
-  MakeCopperList(cp0);
-  CopListActivate(cp0);
+  cp[0] = NewCopList(500);
+  cp[1] = NewCopList(500);
+  MakeCopperList(cp[0]);
+  CopListActivate(cp[0]);
   EnableDMA(DMAF_RASTER);
 }
 
 static void Kill(void) {
   DisableDMA(DMAF_RASTER);
-  DeleteCopList(cp0);
-  DeleteCopList(cp1);
+  DeleteCopList(cp[0]);
+  DeleteCopList(cp[1]);
 }
 
 PROFILE(MakeCopperList);
@@ -183,12 +183,12 @@ static void Render(void) {
   fg_x = normfx(SIN(frameCount * 12) * fg_w) + fg_w;
 
   ProfilerStart(MakeCopperList);
-  MakeCopperList(cp1);
+  MakeCopperList(cp[1]);
   ProfilerStop(MakeCopperList);
 
-  CopListRun(cp1);
+  CopListRun(cp[1]);
   TaskWaitVBlank();
-  swapr(cp0, cp1);
+  { CopListT *tmp = cp[0]; cp[0] = cp[1]; cp[1] = tmp; }
 }
 
 EFFECT(Credits, NULL, NULL, Init, Kill, Render, NULL);

--- a/effects/layers/layers.c
+++ b/effects/layers/layers.c
@@ -15,6 +15,7 @@
 
 static CopListT *cp[2];
 static short fg_y, bg_y, fg_x, bg_x;
+static short active = 0;
 
 #define bg_bplmod ((background_width - (WIDTH + 16)) / 8)
 #define fg_bplmod ((foreground_width - (WIDTH + 16)) / 8)
@@ -183,12 +184,12 @@ static void Render(void) {
   fg_x = normfx(SIN(frameCount * 12) * fg_w) + fg_w;
 
   ProfilerStart(MakeCopperList);
-  MakeCopperList(cp[1]);
+  MakeCopperList(cp[active]);
   ProfilerStop(MakeCopperList);
 
-  CopListRun(cp[1]);
+  CopListRun(cp[active]);
   TaskWaitVBlank();
-  { CopListT *tmp = cp[0]; cp[0] = cp[1]; cp[1] = tmp; }
+  active ^= 1;
 }
 
 EFFECT(Credits, NULL, NULL, Init, Kill, Render, NULL);

--- a/effects/lines/lines.c
+++ b/effects/lines/lines.c
@@ -36,9 +36,8 @@ static void Load(void) {
   SetColor(1, 0xfff);
 
   cp = NewCopList(100);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
 }
 
 static void UnLoad(void) {

--- a/effects/metaballs/metaballs.c
+++ b/effects/metaballs/metaballs.c
@@ -47,7 +47,6 @@ static void Init(void) {
     BitmapCopy(screen[j], WIDTH - 32, 0, &bgRight);
   }
 
-  cp = NewCopList(100);
   carry = NewBitmap(SIZE + 16, SIZE, 2, 0);
 
   SetInitialPositions();
@@ -55,9 +54,9 @@ static void Init(void) {
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
   LoadPalette(&metaball_pal, 0);
 
-  CopInit(cp);
+  cp = NewCopList(100);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/multipipe/multipipe.c
+++ b/effects/multipipe/multipipe.c
@@ -98,11 +98,11 @@ static void UnLoad(void) {
     MemFree(cache[s]);
 }
 
-static void MakeCopperList(CopListT *cp, CopLineT **line) {
-  short i;
+static CopListT *MakeCopperList(CopLineT **line) {
+  CopListT *cp = NewCopList(50 + HEIGHT * 8);
   void *data = cache[0];
+  short i;
 
-  CopInit(cp);
   CopSetColor(cp, 0, 0x000);
   CopSetColor(cp, 1, 0x000);
   for (i = 0; i < HEIGHT; i++) {
@@ -113,7 +113,7 @@ static void MakeCopperList(CopListT *cp, CopLineT **line) {
     CopSetColor(cp, 2, 0x000);
     CopSetColor(cp, 3, 0x000);
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -123,10 +123,8 @@ static void Init(void) {
   SetupDisplayWindow(MODE_LORES, X(0), Y(0), WIDTH, HEIGHT);
   SetupBitplaneFetch(MODE_LORES, X(-16), WIDTH + 16);
 
-  cp[0] = NewCopList(50 + HEIGHT * 8);
-  cp[1] = NewCopList(50 + HEIGHT * 8);
-  MakeCopperList(cp[0], copLines[0]);
-  MakeCopperList(cp[1], copLines[1]);
+  cp[0] = MakeCopperList(copLines[0]);
+  cp[1] = MakeCopperList(copLines[1]);
   CopListActivate(cp[0]);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/neons/neons.c
+++ b/effects/neons/neons.c
@@ -118,6 +118,15 @@ static void CustomRotatePalette(void) {
 
   return;
 }
+  
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(100);
+  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
+  pal = CopLoadPal(cp, palette[0], 0);
+  CopLoadPal(cp, palette[1], 16);
+  CopLoadPal(cp, palette[2], 24);
+  return CopListFinish(cp);
+}
 
 static void Init(void) {
   EnableDMA(DMAF_BLITTER);
@@ -130,14 +139,7 @@ static void Init(void) {
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
 
-  cp = NewCopList(100);
-  CopInit(cp);
-  bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
-  pal = CopLoadPal(cp, palette[0], 0);
-  CopLoadPal(cp, palette[1], 16);
-  CopLoadPal(cp, palette[2], 24);
-  CopEnd(cp);
-
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/plasma/plasma.c
+++ b/effects/plasma/plasma.c
@@ -65,10 +65,10 @@ static void Load(void) {
  * trigger. Thus they must be placed just before the end of scan line.
  * UAE copper debugger facility was used to find the right spot.
  */
-static void MakeCopperList(CopListT *cp, CopInsT **row) {
+static CopListT *MakeCopperList(CopInsT **row) {
+  CopListT *cp = NewCopList(80 + (HTILES + 5) * VTILES);
   short x, y;
 
-  CopInit(cp);
   CopWaitV(cp, VP(0));
 
   for (y = 0; y < VTILES; y++) {
@@ -83,15 +83,12 @@ static void MakeCopperList(CopListT *cp, CopInsT **row) {
     CopMove16(cp, copjmp2, 0);
   }
 
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
-  cp[0] = NewCopList(80 + (HTILES + 5) * VTILES);
-  cp[1] = NewCopList(80 + (HTILES + 5) * VTILES);
-
-  MakeCopperList(cp[0], chunky[0]);
-  MakeCopperList(cp[1], chunky[1]);
+  cp[0] = MakeCopperList(chunky[0]);
+  cp[1] = MakeCopperList(chunky[1]);
 
   CopListActivate(cp[1]);
 }

--- a/effects/playahx/playahx.c
+++ b/effects/playahx/playahx.c
@@ -173,9 +173,8 @@ static void Init(void) {
   SetColor(1, 0xfff);
 
   cp = NewCopList(100);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
 
   ConsoleInit(&console, &latin2, screen);

--- a/effects/playctr/playctr.c
+++ b/effects/playctr/playctr.c
@@ -66,9 +66,8 @@ static void Init(void) {
   SetColor(1, 0xfff);
 
   cp = NewCopList(100);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   ConsoleInit(&console, &latin2, screen);
 

--- a/effects/playp61/playp61.c
+++ b/effects/playp61/playp61.c
@@ -79,9 +79,8 @@ static void Init(void) {
   SetColor(1, 0xfff);
 
   cp = NewCopList(100);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   ConsoleInit(&console, &drdos8x8, screen);
 

--- a/effects/playpt/playpt.c
+++ b/effects/playpt/playpt.c
@@ -46,9 +46,8 @@ static void Init(void) {
   SetColor(1, 0xfff);
 
   cp = NewCopList(100);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   ConsoleInit(&console, &latin2, screen);
 

--- a/effects/plotter/plotter.c
+++ b/effects/plotter/plotter.c
@@ -42,7 +42,6 @@ static void Init(void) {
   }
 
   carry = NewBitmap(SIZE + 16, SIZE, 2, 0);
-  cp = NewCopList(50);
 
   for (i = 0; i < 2; i++)
     BitmapClear(screen[i]);
@@ -50,10 +49,10 @@ static void Init(void) {
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
   LoadPalette(&flares_pal, 0);
 
-  CopInit(cp);
+  cp = NewCopList(50);
   CopWait(cp, Y(-1), 0);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/prisms/prisms.c
+++ b/effects/prisms/prisms.c
@@ -122,10 +122,10 @@ static void GenerateColorShades(void) {
   }
 }
 
-static void MakeCopperList(CopListT *cp, CopLineT **line) {
+static CopListT *MakeCopperList(CopLineT **line) {
+  CopListT *cp = NewCopList(HEIGHT * 5 + 200);
   short i;
 
-  CopInit(cp);
   sprptr = CopSetupSprites(cp);
 
   for (i = 0; i < HEIGHT; i++) {
@@ -135,9 +135,10 @@ static void MakeCopperList(CopListT *cp, CopLineT **line) {
     CopMove32(cp, bplpt[0], rowAddr[0]);
   }
 
-  CopEnd(cp);
-
   ITER(i, 0, 7, CopInsSetSprite(&sprptr[i], &sprite[i]));
+  ITER(i, 0, 7, SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y((256 - 24) / 2)));
+
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -154,13 +155,8 @@ static void Init(void) {
   LoadPalette(&sprite_pal, 24);
   LoadPalette(&sprite_pal, 28);
 
-  cp[0] = NewCopList(HEIGHT * 5 + 200);
-  cp[1] = NewCopList(HEIGHT * 5 + 200);
-
-  MakeCopperList(cp[0], copLines[0]);
-  MakeCopperList(cp[1], copLines[1]);
-
-  ITER(i, 0, 7, SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y((256 - 24) / 2)));
+  cp[0] = MakeCopperList(copLines[0]);
+  cp[1] = MakeCopperList(copLines[1]);
 
   CopListActivate(cp[0]);
   EnableDMA(DMAF_RASTER | DMAF_SPRITE);

--- a/effects/prisms/prisms.c
+++ b/effects/prisms/prisms.c
@@ -57,8 +57,6 @@ static SpanInfoT spanInfo[HEIGHT];
 static PrismT prisms[PRISMS];
 static short active = 0;
 
-static CopInsPairT *sprptr;
-
 static u_short colorSet[NCOLORS] = {
   0xC0F, 0xF0C, 0x80F, 0xF08
 };
@@ -124,9 +122,8 @@ static void GenerateColorShades(void) {
 
 static CopListT *MakeCopperList(CopLineT **line) {
   CopListT *cp = NewCopList(HEIGHT * 5 + 200);
+  CopInsPairT *sprptr = CopSetupSprites(cp);
   short i;
-
-  sprptr = CopSetupSprites(cp);
 
   for (i = 0; i < HEIGHT; i++) {
     CopWait(cp, Y(i - 1), 0xDE);
@@ -135,8 +132,10 @@ static CopListT *MakeCopperList(CopLineT **line) {
     CopMove32(cp, bplpt[0], rowAddr[0]);
   }
 
-  ITER(i, 0, 7, CopInsSetSprite(&sprptr[i], &sprite[i]));
-  ITER(i, 0, 7, SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y((256 - 24) / 2)));
+  for (i = 0; i < 8; i++) {
+    CopInsSetSprite(&sprptr[i], &sprite[i]);
+    SpriteUpdatePos(&sprite[i], X(96 + 16 * i), Y((256 - 24) / 2));
+  }
 
   return CopListFinish(cp);
 }

--- a/effects/rotator/rotator.c
+++ b/effects/rotator/rotator.c
@@ -191,10 +191,10 @@ static void ChunkyToPlanar(void) {
   c2p.phase++;
 }
 
-static void MakeCopperList(CopListT *cp) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(HEIGHT * 2 * (4 - FULLPIXEL) + 50);
   short i;
 
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadPal(cp, &texture_pal, 0);
   for (i = 0; i < HEIGHT * 2; i++) {
@@ -207,7 +207,7 @@ static void MakeCopperList(CopListT *cp) {
     CopMove16(cp, bplcon1, (i & 1) ? 0x0010 : 0x0021);
 #endif
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -225,8 +225,7 @@ static void Init(void) {
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(28), WIDTH * 2, HEIGHT * 2);
 
-  cp = NewCopList(HEIGHT * 2 * (4 - FULLPIXEL) + 50);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/effects/sea-anemone/sea-anemone.c
+++ b/effects/sea-anemone/sea-anemone.c
@@ -186,9 +186,8 @@ static void Init(void) {
   LoadPalette(&anemone_pal, 0);
 
   cp = NewCopList(50);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_BLITHOG);

--- a/effects/shapes/shapes.c
+++ b/effects/shapes/shapes.c
@@ -36,9 +36,8 @@ static void Init(void) {
   LoadPalette(&shapes_pal, 0);
 
   cp = NewCopList(100);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/effects/showpchg/showpchg.c
+++ b/effects/showpchg/showpchg.c
@@ -10,17 +10,9 @@
 
 static CopListT *cp;
 
-static void Init(void) {
-  short w = face.width;
-  short h = face.height;
-  short xs = X((WIDTH - w) / 2);
-  short ys = Y((HEIGHT - h) / 2);
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(100 + face_pchg_count + face.height * 2);
 
-  cp = NewCopList(100 + face_pchg_count + face.height * 2);
-
-  SetupPlayfield(MODE_HAM, DEPTH, xs, ys, w, h);
-
-  CopInit(cp);
   CopSetupBitplanes(cp, &face, DEPTH);
 
   {
@@ -40,10 +32,18 @@ static void Init(void) {
     }
   }
 
-  CopEnd(cp);
+  return CopListFinish(cp);
+}
 
-  Log("Used copper list slots: %ld\n", (ptrdiff_t)(cp->curr - cp->entry));
+static void Init(void) {
+  short w = face.width;
+  short h = face.height;
+  short xs = X((WIDTH - w) / 2);
+  short ys = Y((HEIGHT - h) / 2);
 
+  SetupPlayfield(MODE_HAM, DEPTH, xs, ys, w, h);
+
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);
 }

--- a/effects/stripes/stripes.c
+++ b/effects/stripes/stripes.c
@@ -49,10 +49,10 @@ static void GenerateColorShades(void) {
   }
 }
 
-static void MakeCopperList(CopListT *cp, CopInsT **line) {
+static CopListT *MakeCopperList(CopInsT **line) {
+  CopListT *cp = NewCopList(HEIGHT * 2 + 100);
   short i;
 
-  CopInit(cp);
   CopSetColor(cp, 0, BGCOL);
 
   for (i = 0; i < HEIGHT; i++) {
@@ -62,18 +62,15 @@ static void MakeCopperList(CopListT *cp, CopInsT **line) {
 
   CopWait(cp, Y(256), 8);
   CopSetColor(cp, 0, BGCOL);
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
   GenerateStripes();
   GenerateColorShades();
 
-  cp[0] = NewCopList(HEIGHT * 2 + 100);
-  cp[1] = NewCopList(HEIGHT * 2 + 100);
-
-  MakeCopperList(cp[0], lineColor[0]);
-  MakeCopperList(cp[1], lineColor[1]);
+  cp[0] = MakeCopperList(lineColor[0]);
+  cp[1] = MakeCopperList(lineColor[1]);
 
   CopListActivate(cp[0]);
 }

--- a/effects/textscroll/textscroll.c
+++ b/effects/textscroll/textscroll.c
@@ -29,7 +29,6 @@ extern uint8_t binary_data_text_scroll_txt_start[];
 
 static CopListT *MakeCopperList(short n) {
   CopListT *cp = NewCopList(100 + 3 * HEIGHT);
-  CopInit(cp);
   CopSetupBitplanes(cp, scroll, DEPTH);
   {
     u_short i;
@@ -40,8 +39,7 @@ static CopListT *MakeCopperList(short n) {
       linebpl[n][i] = CopMove32(cp, bplpt[0], ptr);
     }
   }
-  CopEnd(cp);
-  return cp;
+  return CopListFinish(cp);
 }
 
 static void Init(void) {

--- a/effects/thunders/thunders.c
+++ b/effects/thunders/thunders.c
@@ -92,11 +92,11 @@ static void Load(void) {
   ITER(i, 0, SIZE * SIZE - 1, tileCycle[i] = random() & SIN_MASK);
 }
 
-static void MakeCopperList(CopListT *cp, BitmapT *screen) {
-  CopInit(cp);
+static CopListT *MakeCopperList(BitmapT *screen) {
+  CopListT *cp = NewCopList((HEIGHT - FAR_Y) * 16 + 200);
   CopSetupBitplanes(cp, screen, DEPTH);
   CopSetupSprites(cp);
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -106,11 +106,8 @@ static void Init(void) {
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
   ITER(k, 0, 7, SetColor(k, BGCOL));
 
-  cp0 = NewCopList((HEIGHT - FAR_Y) * 16 + 200);
-  cp1 = NewCopList((HEIGHT - FAR_Y) * 16 + 200);
-
-  MakeCopperList(cp0, screen0);
-  MakeCopperList(cp1, screen1);
+  cp0 = MakeCopperList(screen0);
+  cp1 = MakeCopperList(screen1);
 
   EnableDMA(DMAF_BLITTER | DMAF_BLITHOG);
 
@@ -381,7 +378,7 @@ static void ColorizeLowerHalf(CopListT *cp, short yi, short kyo) {
 static void MakeFloorCopperList(short yo, short kyo) {
   CopListT *cp = cp0;
 
-  CopInit(cp);
+  CopListReset(cp);
   {
     void **planes = screen0->planes;
     CopMove32(cp, bplpt[0], (*planes++) + WIDTH * (HEIGHT - 1) / 8);
@@ -414,7 +411,7 @@ static void MakeFloorCopperList(short yo, short kyo) {
   FillStripes(2);
   ColorizeLowerHalf(cp, yo, kyo);
 
-  CopEnd(cp);
+  CopListFinish(cp);
 }
 
 PROFILE(Thunders);

--- a/effects/thunders/thunders.c
+++ b/effects/thunders/thunders.c
@@ -27,7 +27,6 @@
 
 static BitmapT *screen0, *screen1;
 static CopListT *cp0, *cp1;
-static CopInsPairT *sprptr;
 static u_short tileColor[SIZE * SIZE];
 static short tileCycle[SIZE * SIZE];
 static short tileEnergy[SIZE * SIZE];
@@ -95,7 +94,7 @@ static void Load(void) {
 static CopListT *MakeCopperList(BitmapT *screen) {
   CopListT *cp = NewCopList((HEIGHT - FAR_Y) * 16 + 200);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopSetupSprites(cp);
+  (void)CopSetupSprites(cp);
   return CopListFinish(cp);
 }
 
@@ -388,9 +387,8 @@ static void MakeFloorCopperList(short yo, short kyo) {
   CopMove16(cp, bpl1mod, - (WIDTH * 2) / 8);
   CopMove16(cp, bpl2mod, - (WIDTH * 2) / 8);
 
-  sprptr = CopSetupSprites(cp);
- 
   {
+    CopInsPairT *sprptr = CopSetupSprites(cp);
     short i = mod16(frameCount, 10) * 2;
 
     CopInsSetSprite(&sprptr[0], &thunder[i]);

--- a/effects/tiles16/tiles16.c
+++ b/effects/tiles16/tiles16.c
@@ -51,11 +51,11 @@ static void Load(void) {
   }
 }
 
-static void MakeCopperList(CopListT *cp, int i) {
-  CopInit(cp);
+static CopListT *MakeCopperList(int i) {
+  CopListT *cp = NewCopList(100);
   bplptr[i] = CopSetupBitplanes(cp, screen[i], DEPTH);
   bplcon1[i] = CopMove16(cp, bplcon1, 0);
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -75,10 +75,8 @@ static void Init(void) {
   SetupBitplaneFetch(MODE_LORES, X(-16), WIDTH);
   LoadPalette(&tiles_pal, 0);
 
-  cp[0] = NewCopList(100);
-  MakeCopperList(cp[0], 0);
-  cp[1] = NewCopList(100);
-  MakeCopperList(cp[1], 1);
+  cp[0] = MakeCopperList(0);
+  cp[1] = MakeCopperList(1);
 
   CopListActivate(cp[1]);
 

--- a/effects/tiles8/tiles8.c
+++ b/effects/tiles8/tiles8.c
@@ -51,16 +51,9 @@ static void Load(void) {
   }
 }
 
-static void Init(void) {
-  screen0 = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
-  screen1 = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(80 + (HTILES + 4) * VTILES);
 
-  SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
-  LoadPalette(&tilegfx_pal, 0);
-
-  cp = NewCopList(80 + (HTILES + 4) * VTILES);
-
-  CopInit(cp);
   /* X(-1) to align with copper induced color changes */
   bplptr = CopSetupBitplanes(cp, screen1, DEPTH);
   CopWaitV(cp, VP(0));
@@ -95,8 +88,17 @@ static void Init(void) {
       CopMove16(cp, copjmp2, 0);
     }
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
+}
 
+static void Init(void) {
+  screen0 = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
+  screen1 = NewBitmap(WIDTH, HEIGHT, DEPTH, BM_CLEAR);
+
+  SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(0), WIDTH, HEIGHT);
+  LoadPalette(&tilegfx_pal, 0);
+
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_BLITHOG);

--- a/effects/tilezoomer/tilezoomer.c
+++ b/effects/tilezoomer/tilezoomer.c
@@ -123,6 +123,21 @@ void CalculateTiles(int *tile, short fx, short tx, short fy, short ty, u_short f
   }
 }
 
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(100);
+#if MOTIONBLUR
+  bplptr = CopSetupBitplanes(cp, screen0, SHADOW);
+  CopMove16(cp, bpl1mod, MARGIN / 8);
+  CopMove16(cp, bpl2mod, MARGIN / 8);
+#else
+  bplptr = CopSetupBitplanes(cp, screen0, DEPTH);
+  /* Screen bitplanes are interleaved! */
+  CopMove16(cp, bpl1mod, (WIDTH * (DEPTH - 1) + MARGIN) / 8);
+  CopMove16(cp, bpl2mod, (WIDTH * (DEPTH - 1) + MARGIN) / 8);
+#endif
+  return CopListFinish(cp);
+}
+
 static void Init(void) {
   CalculateTiles(tiles, SIN_PI/3, SIN_PI, -SIN_PI/3, SIN_PI/12, 0);
 
@@ -146,20 +161,7 @@ static void Init(void) {
   SetColor(3, 0xccf);
 #endif
 
-  cp = NewCopList(100);
-  CopInit(cp);
-#if MOTIONBLUR
-  bplptr = CopSetupBitplanes(cp, screen0, SHADOW);
-  CopMove16(cp, bpl1mod, MARGIN / 8);
-  CopMove16(cp, bpl2mod, MARGIN / 8);
-#else
-  bplptr = CopSetupBitplanes(cp, screen0, DEPTH);
-  /* Screen bitplanes are interleaved! */
-  CopMove16(cp, bpl1mod, (WIDTH * (DEPTH - 1) + MARGIN) / 8);
-  CopMove16(cp, bpl2mod, (WIDTH * (DEPTH - 1) + MARGIN) / 8);
-#endif
-  CopEnd(cp);
-
+  cp = MakeCopperList();
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER | DMAF_BLITTER | DMAF_BLITHOG);
 }

--- a/effects/transparency/transparency.c
+++ b/effects/transparency/transparency.c
@@ -59,10 +59,9 @@ static void Init(void) {
   LoadPalette(&background_pal, 0);
 
   cp = NewCopList(100);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
   pal = CopLoadColor(cp, 8, 31, 0);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   CopListActivate(cp);
   EnableDMA(DMAF_RASTER);

--- a/effects/twister-rgb/twister-rgb.c
+++ b/effects/twister-rgb/twister-rgb.c
@@ -17,8 +17,6 @@ static CopInsT *bplmod[2][HEIGHT];
 static CopInsT *colors[2][HEIGHT];
 static short active = 0;
 
-static CopInsPairT *sprptr[2];
-
 #include "data/twister-gradient.c"
 #include "data/twister-texture.c"
 #include "data/twister-left.c"
@@ -27,11 +25,12 @@ static CopInsPairT *sprptr[2];
 
 static CopListT *MakeCopperList(short n) {
   CopListT *cp = NewCopList(100 + HEIGHT * 5 + (31 * HEIGHT / 3));
+  CopInsPairT *sprptr = CopSetupSprites(cp);
   short *pixels = texture.pixels;
   short i, j, k;
 
   bplptr[n] = CopSetupBitplanes(cp, &twister, DEPTH);
-  sprptr[n] = CopSetupSprites(cp);
+  
   CopMove16(cp, dmacon, DMAF_SETCLR|DMAF_RASTER);
   CopSetColor(cp, 0, gradient.colors[0]);
 
@@ -50,10 +49,10 @@ static CopListT *MakeCopperList(short n) {
     }
   }
 
-  CopInsSetSprite(&sprptr[n][4], &left[0]);
-  CopInsSetSprite(&sprptr[n][5], &left[1]);
-  CopInsSetSprite(&sprptr[n][6], &right[0]);
-  CopInsSetSprite(&sprptr[n][7], &right[1]);
+  CopInsSetSprite(&sprptr[4], &left[0]);
+  CopInsSetSprite(&sprptr[5], &left[1]);
+  CopInsSetSprite(&sprptr[6], &right[0]);
+  CopInsSetSprite(&sprptr[7], &right[1]);
 
   return CopListFinish(cp);
 }

--- a/effects/twister-rgb/twister-rgb.c
+++ b/effects/twister-rgb/twister-rgb.c
@@ -25,12 +25,11 @@ static CopInsPairT *sprptr[2];
 #include "data/twister-right.c"
 #include "data/twister.c"
 
-static void MakeCopperList(CopListT **ptr, short n) {
+static CopListT *MakeCopperList(short n) {
   CopListT *cp = NewCopList(100 + HEIGHT * 5 + (31 * HEIGHT / 3));
   short *pixels = texture.pixels;
   short i, j, k;
 
-  CopInit(cp);
   bplptr[n] = CopSetupBitplanes(cp, &twister, DEPTH);
   sprptr[n] = CopSetupSprites(cp);
   CopMove16(cp, dmacon, DMAF_SETCLR|DMAF_RASTER);
@@ -51,14 +50,12 @@ static void MakeCopperList(CopListT **ptr, short n) {
     }
   }
 
-  CopEnd(cp);
-
   CopInsSetSprite(&sprptr[n][4], &left[0]);
   CopInsSetSprite(&sprptr[n][5], &left[1]);
   CopInsSetSprite(&sprptr[n][6], &right[0]);
   CopInsSetSprite(&sprptr[n][7], &right[1]);
 
-  *ptr = cp;
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -68,8 +65,8 @@ static void Init(void) {
   custom->diwstrt = 0x2c81;
   custom->diwstop = 0x2bc1;
 
-  MakeCopperList(&cp[0], 0);
-  MakeCopperList(&cp[1], 1);
+  cp[0] = MakeCopperList(0);
+  cp[1] = MakeCopperList(1);
 
   SpriteUpdatePos(&left[0], X(0), Y(0));
   SpriteUpdatePos(&left[1], X(16), Y(0));

--- a/effects/uvlight/uvlight.c
+++ b/effects/uvlight/uvlight.c
@@ -256,10 +256,10 @@ static void ChunkyToPlanar(void) {
   ClearIRQ(INTF_BLIT);
 }
 
-static void MakeCopperList(CopListT *cp) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(1200);
   short i;
 
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadColor(cp, 0, 15, 0);
   for (i = 0; i < HEIGHT * 4; i++) {
@@ -270,7 +270,7 @@ static void MakeCopperList(CopListT *cp) {
     /* Alternating shift by one for bitplane data. */
     CopMove16(cp, bplcon1, (i & 1) ? 0x0022 : 0x0000);
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -294,8 +294,7 @@ static void Init(void) {
   custom->bpldat[4] = 0x7777; // rgbb: 0111
   custom->bpldat[5] = 0xcccc; // rgbb: 1100
 
-  cp = NewCopList(1200);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/effects/uvmap-rgb/uvmap-rgb.c
+++ b/effects/uvmap-rgb/uvmap-rgb.c
@@ -212,10 +212,10 @@ static void ChunkyToPlanar(void) {
   ClearIRQ(INTF_BLIT);
 }
 
-static void MakeCopperList(CopListT *cp) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(1200);
   short i;
 
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   CopLoadColor(cp, 0, 15, 0);
   for (i = 0; i < HEIGHT * 4; i++) {
@@ -226,7 +226,7 @@ static void MakeCopperList(CopListT *cp) {
     /* Alternating shift by one for bitplane data. */
     CopMove16(cp, bplcon1, (i & 1) ? 0x0022 : 0x0000);
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -249,8 +249,7 @@ static void Init(void) {
   custom->bpldat[4] = 0x7777; // rgbb: 0111
   custom->bpldat[5] = 0xcccc; // rgbb: 1100
 
-  cp = NewCopList(1200);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/effects/uvmap/uvmap.c
+++ b/effects/uvmap/uvmap.c
@@ -225,11 +225,11 @@ static void ChunkyToPlanar(void) {
   c2p.phase++;
 }
 
-static void MakeCopperList(CopListT *cp) {
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(900 + 256);
   short *pixels = gradient.pixels;
   short i, j;
 
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   for (j = 0; j < 16; j++)
     CopSetColor(cp, j, *pixels++);
@@ -246,7 +246,7 @@ static void MakeCopperList(CopListT *cp) {
       for (j = 0; j < 16; j++)
         CopSetColor(cp, j, *pixels++);
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void Init(void) {
@@ -267,8 +267,7 @@ static void Init(void) {
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(28), WIDTH * 2, HEIGHT * 2);
 
-  cp = NewCopList(900 + 256);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/effects/weave/weave.c
+++ b/effects/weave/weave.c
@@ -55,10 +55,11 @@ static inline void CopSpriteSetHP(CopListT *cp, short n) {
   CopMove16(cp, spr[n * 2 + 1].pos, 0);
 }
 
-static void MakeCopperList(CopListT *cp, StateT *state) {
-  short b, y;
+#define COPLIST_SIZE (HEIGHT * 22 + 100)
 
-  CopInit(cp);
+static CopListT *MakeCopperList(StateT *state) {
+  CopListT *cp = NewCopList(COPLIST_SIZE);
+  short b, y;
 
   /* Setup initial bitplane pointers. */
   state->bar = CopMove32(cp, bplpt[0], NULL);
@@ -151,7 +152,7 @@ static void MakeCopperList(CopListT *cp, StateT *state) {
     }
   }
 
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void UpdateBarState(StateT *state) {
@@ -254,8 +255,6 @@ static void MakeSinTab8(void) {
     sintab8[i] = (sintab[j] + 512) >> 10;
 }
 
-#define COPLIST_SIZE (HEIGHT * 22 + 100)
-
 static void Init(void) {
   MakeSinTab8();
 
@@ -273,15 +272,10 @@ static void Init(void) {
   SpriteUpdatePos(&stripes[2], X(0), Y(0));
   SpriteUpdatePos(&stripes[3], X(0), Y(0));
 
-  cp[0] = NewCopList(COPLIST_SIZE);
-  cp[1] = NewCopList(COPLIST_SIZE);
-
-  MakeCopperList(cp[0], &state[0]);
-  MakeCopperList(cp[1], &state[1]);
+  cp[0] = MakeCopperList(&state[0]);
+  cp[1] = MakeCopperList(&state[1]);
   CopListActivate(cp[0]);
 
-  Log("CopperList: %ld instructions left\n",
-      COPLIST_SIZE - (cp[0]->curr - cp[0]->entry));
   EnableDMA(DMAF_RASTER|DMAF_SPRITE);
 }
 

--- a/effects/wireframe/wireframe.c
+++ b/effects/wireframe/wireframe.c
@@ -40,9 +40,8 @@ static void Init(void) {
   LoadPalette(&wireframe_pal, 0);
 
   cp = NewCopList(80);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
   EnableDMA(DMAF_BLITTER | DMAF_RASTER | DMAF_BLITHOG);
 }

--- a/include/copper.h
+++ b/include/copper.h
@@ -46,24 +46,17 @@ typedef struct {
   CopInsT entry[0]; 
 } CopListT;
 
-CopListT *NewCopList(u_short length);
+/* @brief Returns a new copper list of `length` entries ready to be used. */
+CopListT *NewCopList(int length);
+
+/* @brief Reclaim memory used by the copper list. */
 void DeleteCopList(CopListT *list);
 
-static inline void CopInit(CopListT *list) {
-  list->curr = list->entry;
-  list->overflow = 0;
-}
+/* @brief Reuse existing copper list by resetting to initial state. */
+void CopListReset(CopListT *list);
 
-static inline void CopEnd(CopListT *list) {
-  CopInsT *ins = list->curr;
-  *((u_int *)ins)++ = 0xfffffffe;
-  list->curr = ins;
-}
-
-/* @brief Return a pointer to the current copper instruction pointer. */
-static inline void *CopInsPtr(CopListT *list) {
-  return list->curr;
-}
+/* @brief Finish off copper list by inserting special WAIT instruction. */
+CopListT *CopListFinish(CopListT *list);
 
 /* @brief Enable copper and activate copper list.
  * @warning This function busy-waits for vertical blank. */
@@ -72,6 +65,11 @@ void CopListActivate(CopListT *list);
 /* @brief Set up copper list to start after vertical blank. */
 static inline void CopListRun(CopListT *list) {
   custom->cop1lc = (u_int)list->entry;
+}
+
+/* @brief Return a pointer to the current copper instruction pointer. */
+static inline void *CopInsPtr(CopListT *list) {
+  return list->curr;
 }
 
 /* Low-level functions */

--- a/intro/game-of-life.c
+++ b/intro/game-of-life.c
@@ -218,13 +218,13 @@ static void BlitFunc(const BitmapT *sourceA, const BitmapT *sourceB,
   custom->bltsize = BLTSIZE;
 }
 
-void MakeCopperList(CopListT *cp) {
-  short i;
+static CopListT *MakeCopperList(void) {
+  CopListT *cp = NewCopList(1310);
   short *color = wireworld_pcb_pal_pixels;
   short display_bg = TrackValueGet(&WireworldDisplayBg, frameCount);
   short pal_start = display_bg ? 8 : 0;
+  short i;
 
-  CopInit(cp);
   // initially previous states are empty
   // save addresses of these instructions to change bitplane
   // order when new state gets generated
@@ -282,7 +282,8 @@ void MakeCopperList(CopListT *cp) {
     CopMove16(cp, bpl2mod, 0);
     CopWaitSafe(cp, Y(i + 1), 0);
   }
-  CopEnd(cp);
+
+  return CopListFinish(cp);
 }
 
 static void UpdateBitplanePointers(void) {
@@ -426,8 +427,7 @@ static void SharedPreInit(void) {
 
   SetupPlayfield(MODE_LORES, DISP_DEPTH, X(0), Y(0), DISP_WIDTH, DISP_HEIGHT);
 
-  cp = NewCopList(1310);
-  MakeCopperList(cp);
+  cp = MakeCopperList();
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER | DMAF_SPRITE);

--- a/intro/growing-tree.c
+++ b/intro/growing-tree.c
@@ -198,10 +198,9 @@ static void Init(void) {
   custom->bplcon2 = BPLCON2_PF1P2;
 
   cp = NewCopList(50);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   sprptr = CopSetupSprites(cp);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   CopListActivate(cp);
 

--- a/intro/logo.c
+++ b/intro/logo.c
@@ -54,9 +54,8 @@ static void SharedInit(bool out) {
   DisableDMA(DMAF_BLITTER);
 
   cp = NewCopList(40);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
 
   CopListActivate(cp);
 

--- a/intro/sea-anemone.c
+++ b/intro/sea-anemone.c
@@ -375,7 +375,6 @@ static CopListT *MakeCopperList(int active) {
   CopInsT **insptr = colins[active];
   short i;
 
-  CopInit(cp);
   bplptr[active] = CopSetupBitplanes(cp, screen, DEPTH);
   sprptr[active] = CopSetupSprites(cp);
 
@@ -385,8 +384,7 @@ static CopListT *MakeCopperList(int active) {
     *insptr++ = CopSetColor(cp, 0, 0);
   }
 
-  CopEnd(cp);
-  return cp;
+  return CopListFinish(cp);
 }
 
 static void Init(void) {

--- a/intro/textscroll.c
+++ b/intro/textscroll.c
@@ -30,7 +30,6 @@ extern uint8_t Text[];
 
 static CopListT *MakeCopperList(CopInsPairT **linebpl) {
   CopListT *cp = NewCopList(100 + 3 * HEIGHT);
-  CopInit(cp);
   CopSetupBitplanes(cp, scroll, DEPTH);
   {
     void *ptr = scroll->planes[0];
@@ -47,8 +46,7 @@ static CopListT *MakeCopperList(CopInsPairT **linebpl) {
       linebpl[y] = CopMove32(cp, bplpt[0], ptr);
     }
   }
-  CopEnd(cp);
-  return cp;
+  return CopListFinish(cp);
 }
 
 static void Init(void) {

--- a/intro/tilemover.c
+++ b/intro/tilemover.c
@@ -288,11 +288,10 @@ static void Init(void) {
   KillLogo();
 
   cp = NewCopList(100);
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen, DEPTH);
   CopMove16(cp, bpl1mod, (WIDTH - S_WIDTH) / 8);
   CopMove16(cp, bpl2mod, (WIDTH - S_WIDTH) / 8);
-  CopEnd(cp);
+  CopListFinish(cp);
  
   CopListActivate(cp);
   

--- a/intro/turmite.c
+++ b/intro/turmite.c
@@ -605,9 +605,8 @@ static void Init(void) {
   ChooseTurmiteBoard(1);
 
   cp = NewCopList(100);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
+  CopListFinish(cp);
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/intro/uvmap.c
+++ b/intro/uvmap.c
@@ -336,10 +336,10 @@ static void ChunkyToPlanar(void) {
   c2p_phase++;
 }
 
-static void MakeCopperList(CopListT *cp, short *pixels) {
+static CopListT *MakeCopperList(short *pixels) {
+  CopListT *cp = NewCopList(900 + 256);
   short i, j;
 
-  CopInit(cp);
   bplptr = CopSetupBitplanes(cp, screen[active], DEPTH);
   sprptr = CopSetupSprites(cp);
   for (j = 0; j < 16; j++)
@@ -357,7 +357,7 @@ static void MakeCopperList(CopListT *cp, short *pixels) {
       for (j = 0; j < 16; j++)
         CopSetColor(cp, j, *pixels++);
   }
-  CopEnd(cp);
+  return CopListFinish(cp);
 }
 
 static void VBlank(void) {
@@ -396,8 +396,7 @@ static void Init(short var) {
 
   SetupPlayfield(MODE_LORES, DEPTH, X(0), Y(28), WIDTH * 2, HEIGHT * 2);
 
-  cp = NewCopList(900 + 256);
-  MakeCopperList(cp, var ? uvtit_gradient_pixels : uvgut_gradient_pixels);
+  cp = MakeCopperList(var ? uvtit_gradient_pixels : uvgut_gradient_pixels);
   CopListActivate(cp);
 
   if (var) {

--- a/intro/vitruvian.c
+++ b/intro/vitruvian.c
@@ -45,10 +45,8 @@ static void Init(void) {
   }
 
   cp = NewCopList(40);
-  CopInit(cp);
   CopSetupBitplanes(cp, screen, DEPTH);
-  CopEnd(cp);
-
+  CopListFinish(cp);
   CopListActivate(cp);
 
   EnableDMA(DMAF_RASTER);

--- a/intro/weave.c
+++ b/intro/weave.c
@@ -75,11 +75,11 @@ static inline void CopSpriteSetHP(CopListT *cp, short n) {
   CopMove16(cp, spr[n * 2 + 1].pos, 0);
 }
 
-static void MakeCopperListFull(StateFullT *state) {
-  short b, y, i;
-  CopListT *cp = state->cp;
+#define CP_FULL_SIZE (HEIGHT * 22 + 100)
 
-  CopInit(cp);
+static void MakeCopperListFull(StateFullT *state) {
+  CopListT *cp = NewCopList(CP_FULL_SIZE);
+  short b, y, i;
 
   /* Setup initial bitplane pointers. */
   for (i = 0; i < DEPTH; i++)
@@ -153,12 +153,14 @@ static void MakeCopperListFull(StateFullT *state) {
     }
   }
 
-  CopEnd(cp);
+  state->cp = CopListFinish(cp);
 }
 
+#define CP_BARS_SIZE 500
+
 static void MakeCopperListBars(StateBarT *bars, bool color) {
+  CopListT *cp = NewCopList(CP_BARS_SIZE);
   short b, by, y, i;
-  CopListT *cp = bars->cp;
 
   for (b = 0; b < BARS; b++) {
     bars->bar[b] = NULL;
@@ -166,8 +168,6 @@ static void MakeCopperListBars(StateBarT *bars, bool color) {
     if (by >= -33)
       break;
   }
-
-  CopInit(cp);
 
   /* Setup initial bitplane pointers. */
   for (i = 0; i < DEPTH; i++)
@@ -201,7 +201,7 @@ static void MakeCopperListBars(StateBarT *bars, bool color) {
     }
   }
 
-  CopEnd(cp);
+  bars->cp = CopListFinish(cp);
 }
 
 static void UpdateBarColor(StateBarT *bars, short step) {
@@ -296,9 +296,6 @@ static void UpdateStripeState(StateFullT *state) {
     } while (--n != -1);
   }
 }
-
-#define CP_FULL_SIZE (HEIGHT * 22 + 100)
-#define CP_BARS_SIZE (500)
 
 /* For both {Copy,Zero}SpriteTiles `t` controls which quarter of stripe,
  * i.e. tile has to be copied or cleared respectively. Note that all 8
@@ -451,14 +448,10 @@ static void Init(void) {
   }
 
   stateFull = MemAlloc(sizeof(StateFullT) * 2, MEMF_PUBLIC|MEMF_CLEAR);
-  stateFull[0].cp = NewCopList(CP_FULL_SIZE);
-  stateFull[1].cp = NewCopList(CP_FULL_SIZE);
   MakeCopperListFull(&stateFull[0]);
   MakeCopperListFull(&stateFull[1]);
 
   stateBars = MemAlloc(sizeof(StateBarT) * 2, MEMF_PUBLIC|MEMF_CLEAR);
-  stateBars[0].cp = NewCopList(CP_BARS_SIZE);
-  stateBars[1].cp = NewCopList(CP_BARS_SIZE);
   MakeCopperListBars(&stateBars[0], false);
   MakeCopperListBars(&stateBars[1], false);
 

--- a/lib/libgfx/CopListFinish.c
+++ b/lib/libgfx/CopListFinish.c
@@ -1,0 +1,10 @@
+#include <copper.h>
+#include <debug.h>
+
+CopListT *CopListFinish(CopListT *list) {
+  CopInsT *ins = list->curr;
+  *((u_int *)ins)++ = 0xfffffffe;
+  list->curr = ins;
+  Log("Used copper list slots: %ld\n", (ptrdiff_t)(list->curr - list->entry));
+  return list;
+}

--- a/lib/libgfx/CopListFinish.c
+++ b/lib/libgfx/CopListFinish.c
@@ -5,6 +5,11 @@ CopListT *CopListFinish(CopListT *list) {
   CopInsT *ins = list->curr;
   *((u_int *)ins)++ = 0xfffffffe;
   list->curr = ins;
-  Log("Used copper list slots: %ld\n", (ptrdiff_t)(list->curr - list->entry));
+  {
+    ptrdiff_t used = (ptrdiff_t)(list->curr - list->entry);
+    Log("Used copper list %p slots: %ld/%d\n", list, used, list->length);
+    if (used > list->length)
+      PANIC();
+  }
   return list;
 }

--- a/lib/libgfx/CopListReset.c
+++ b/lib/libgfx/CopListReset.c
@@ -1,0 +1,6 @@
+#include <copper.h>
+
+void CopListReset(CopListT *list) {
+  list->curr = list->entry;
+  list->overflow = 0;
+}

--- a/lib/libgfx/Makefile
+++ b/lib/libgfx/Makefile
@@ -10,6 +10,8 @@ SOURCES := \
 	ColorTab.c \
 	ColorTransition.c \
 	CopListActivate.c \
+	CopListReset.c \
+	CopListFinish.c \
 	CopLoadColor.c \
 	CopLoadColorArray.c \
 	CopLoadPal.c \

--- a/lib/libgfx/NewCopList.c
+++ b/lib/libgfx/NewCopList.c
@@ -1,10 +1,11 @@
 #include <copper.h>
 #include <system/memory.h>
 
-CopListT *NewCopList(u_short length) {
+CopListT *NewCopList(int length) {
   CopListT *list =
     MemAlloc(sizeof(CopListT) + length * sizeof(CopInsT), MEMF_CHIP);
   list->length = length;
-  CopInit(list);
+  list->curr = list->entry;
+  list->overflow = 0;
   return list;
 }


### PR DESCRIPTION
 * Replace CopInit with CopListReset.
 * NewCopList initialises the list by default (as if CopListReset was called).
 * Replace CopEnd with CopListFinish that returns copper list pointer.
 * Clean up MakeCopperList in the effects.
 * Panic if used more copper list entries than available.